### PR TITLE
Run clippy in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,6 +40,9 @@ jobs:
     # Check the submitted change meets style guidelines
     - name: Cargo Format
       run: cargo fmt --check
+    # Check the submitted change passes the clippy linter
+    - name: Cargo Clippy
+      run: cargo clippy --release --all-targets -- --deny warnings
     # Build and run the tests
     - name: Build and run tests
       run: cargo test --verbose --release

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -40,9 +40,6 @@ jobs:
     # Check the submitted change meets style guidelines
     - name: Cargo Format
       run: cargo fmt --check
-    # Check the submitted change passes the clippy linter
-    - name: Cargo Clippy
-      run: cargo clippy --release --all-targets -- --deny warnings
     # Build and run the tests
     - name: Build and run tests
       run: cargo test --verbose --release
@@ -67,6 +64,25 @@ jobs:
     - name: Test docs
       run: ../mdBook/target/release/mdbook test -L dependency=../target/release/deps --extern sunscreen=../target/release/libsunscreen.rlib --extern bincode=../target/release/libbincode.rlib
       working-directory: ./sunscreen_docs
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: 'recursive'
+    - uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cargo/bin/
+          ~/.cargo/registry/index/
+          ~/.cargo/registry/cache/
+          ~/.cargo/git/db/
+          target/
+        key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('Cargo.lock') }}
+    # Check the submitted change passes the clippy linter
+    - name: Cargo clippy
+      run: cargo clippy --release --all-targets -- --deny warnings
 
   api_docs:
     runs-on: ubuntu-latest

--- a/benchmarks/cannonical_norm_noise_model/src/main.rs
+++ b/benchmarks/cannonical_norm_noise_model/src/main.rs
@@ -74,6 +74,7 @@ impl Results {
         Self { output_file }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn output_row(
         &mut self,
         params: &Params,
@@ -85,8 +86,8 @@ impl Results {
         modeled: &Stats,
         diff: &Stats,
     ) {
-        let n_a = n_a.map(|x| x.to_string()).unwrap_or("".to_owned());
-        let n_b = n_b.map(|x| x.to_string()).unwrap_or("".to_owned());
+        let n_a = n_a.map(|x| x.to_string()).unwrap_or_else(|| "".to_owned());
+        let n_b = n_b.map(|x| x.to_string()).unwrap_or_else(|| "".to_owned());
 
         let security_level = match params.security_level {
             SecurityLevel::TC128 => 128,
@@ -118,6 +119,12 @@ impl Results {
             diff.max
         )
         .unwrap();
+    }
+}
+
+impl Default for Results {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/benchmarks/cannonical_norm_noise_model/src/ops.rs
+++ b/benchmarks/cannonical_norm_noise_model/src/ops.rs
@@ -185,7 +185,7 @@ fn create_ciphertext(
         }
     }
 
-    return Err(Error::ImpossibleNoiseFloor);
+    Err(Error::ImpossibleNoiseFloor)
 }
 
 pub fn add_noise(

--- a/emsdk/src/lib.rs
+++ b/emsdk/src/lib.rs
@@ -12,7 +12,7 @@ pub struct Config {
 impl Config {
     pub fn new<P: AsRef<Path>>(path: P) -> Self {
         Self {
-            path: path.as_ref().canonicalize().unwrap().to_owned(),
+            path: path.as_ref().canonicalize().unwrap(),
             defines: HashMap::new(),
             emcc_args: vec![],
         }

--- a/examples/calculator_fractional/src/main.rs
+++ b/examples/calculator_fractional/src/main.rs
@@ -18,7 +18,7 @@ fn help() {
     println!("9.5");
     println!(">> ans / 5");
     println!("1.9");
-    println!("");
+    println!();
 }
 
 enum Term {
@@ -63,7 +63,7 @@ fn parse_input(line: &str) -> Result<ParseResult, Error> {
         return Ok(ParseResult::Exit);
     }
 
-    let mut terms = line.split(" ");
+    let mut terms = line.split(' ');
 
     let left = terms.next().ok_or(Error::ParseError)?;
 
@@ -119,7 +119,7 @@ fn encrypt_term(runtime: &Runtime, public_key: &PublicKey, input: Term) -> Term 
         Term::Ans => Term::Ans,
         Term::F64(v) => Term::Encrypted(
             runtime
-                .encrypt(Fractional::<64>::try_from(v).unwrap(), &public_key)
+                .encrypt(Fractional::<64>::try_from(v).unwrap(), public_key)
                 .unwrap(),
         ),
         _ => {
@@ -160,7 +160,7 @@ fn alice(
             let line = line.trim();
 
             // Read the line and parse it into operands and an operator.
-            let parsed = parse_input(&line);
+            let parsed = parse_input(line);
 
             let Expression { left, right, op } = match parsed {
                 Ok(ParseResult::Expression(val)) => val,
@@ -184,7 +184,7 @@ fn alice(
                 .send(Expression {
                     left: encrypt_left,
                     right: encrypt_right,
-                    op: op,
+                    op,
                 })
                 .unwrap();
 

--- a/examples/calculator_fractional/src/main.rs
+++ b/examples/calculator_fractional/src/main.rs
@@ -44,7 +44,7 @@ struct Expression {
 enum ParseResult {
     Help,
     Exit,
-    Expression(Expression),
+    Expression(Box<Expression>),
 }
 
 enum Error {
@@ -107,11 +107,11 @@ fn parse_input(line: &str) -> Result<ParseResult, Error> {
         Term::F64(right)
     };
 
-    Ok(ParseResult::Expression(Expression {
+    Ok(ParseResult::Expression(Box::new(Expression {
         left: left_term,
         op: operand,
         right: right_term,
-    }))
+    })))
 }
 
 fn encrypt_term(runtime: &Runtime, public_key: &PublicKey, input: Term) -> Term {
@@ -163,7 +163,7 @@ fn alice(
             let parsed = parse_input(line);
 
             let Expression { left, right, op } = match parsed {
-                Ok(ParseResult::Expression(val)) => val,
+                Ok(ParseResult::Expression(val)) => *val,
                 Ok(ParseResult::Exit) => std::process::exit(0),
                 Ok(ParseResult::Help) => {
                     help();

--- a/examples/calculator_fractional/src/main.rs
+++ b/examples/calculator_fractional/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::large_enum_variant)]
+
 use std::io::{self, Write};
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread::{self, JoinHandle};
@@ -44,7 +46,7 @@ struct Expression {
 enum ParseResult {
     Help,
     Exit,
-    Expression(Box<Expression>),
+    Expression(Expression),
 }
 
 enum Error {
@@ -107,11 +109,11 @@ fn parse_input(line: &str) -> Result<ParseResult, Error> {
         Term::F64(right)
     };
 
-    Ok(ParseResult::Expression(Box::new(Expression {
+    Ok(ParseResult::Expression(Expression {
         left: left_term,
         op: operand,
         right: right_term,
-    })))
+    }))
 }
 
 fn encrypt_term(runtime: &Runtime, public_key: &PublicKey, input: Term) -> Term {
@@ -163,7 +165,7 @@ fn alice(
             let parsed = parse_input(line);
 
             let Expression { left, right, op } = match parsed {
-                Ok(ParseResult::Expression(val)) => *val,
+                Ok(ParseResult::Expression(val)) => val,
                 Ok(ParseResult::Exit) => std::process::exit(0),
                 Ok(ParseResult::Help) => {
                     help();

--- a/examples/calculator_rational/src/main.rs
+++ b/examples/calculator_rational/src/main.rs
@@ -18,7 +18,7 @@ fn help() {
     println!("9.5");
     println!(">> ans / 5");
     println!("1.9");
-    println!("");
+    println!();
 }
 
 enum Term {
@@ -57,7 +57,7 @@ fn parse_input(line: &str) -> Result<ParseResult, Error> {
         return Ok(ParseResult::Exit);
     }
 
-    let mut terms = line.split(" ");
+    let mut terms = line.split(' ');
 
     let left = terms.next().ok_or(Error::ParseError)?;
 
@@ -101,7 +101,7 @@ fn encrypt_term(runtime: &Runtime, public_key: &PublicKey, input: Term) -> Term 
         Term::Ans => Term::Ans,
         Term::F64(v) => Term::Encrypted(
             runtime
-                .encrypt(Rational::try_from(v).unwrap(), &public_key)
+                .encrypt(Rational::try_from(v).unwrap(), public_key)
                 .unwrap(),
         ),
         _ => {
@@ -142,7 +142,7 @@ fn alice(
             let line = line.trim();
 
             // Read the line and parse it into operands and an operator.
-            let parsed = parse_input(&line);
+            let parsed = parse_input(line);
 
             let Expression { left, right, op } = match parsed {
                 Ok(ParseResult::Expression(val)) => val,
@@ -166,7 +166,7 @@ fn alice(
                 .send(Expression {
                     left: encrypt_left,
                     right: encrypt_right,
-                    op: op,
+                    op,
                 })
                 .unwrap();
 

--- a/examples/calculator_rational/src/main.rs
+++ b/examples/calculator_rational/src/main.rs
@@ -43,7 +43,7 @@ struct Expression {
 enum ParseResult {
     Help,
     Exit,
-    Expression(Expression),
+    Expression(Box<Expression>),
 }
 
 enum Error {
@@ -89,11 +89,11 @@ fn parse_input(line: &str) -> Result<ParseResult, Error> {
         Term::F64(right.parse::<f64>().map_err(|_| Error::ParseError)?)
     };
 
-    Ok(ParseResult::Expression(Expression {
+    Ok(ParseResult::Expression(Box::new(Expression {
         left: left_term,
         op: operand,
         right: right_term,
-    }))
+    })))
 }
 
 fn encrypt_term(runtime: &Runtime, public_key: &PublicKey, input: Term) -> Term {
@@ -145,7 +145,7 @@ fn alice(
             let parsed = parse_input(line);
 
             let Expression { left, right, op } = match parsed {
-                Ok(ParseResult::Expression(val)) => val,
+                Ok(ParseResult::Expression(val)) => *val,
                 Ok(ParseResult::Exit) => std::process::exit(0),
                 Ok(ParseResult::Help) => {
                     help();

--- a/examples/calculator_rational/src/main.rs
+++ b/examples/calculator_rational/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::large_enum_variant)]
+
 use std::io::{self, Write};
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread::{self, JoinHandle};
@@ -43,7 +45,7 @@ struct Expression {
 enum ParseResult {
     Help,
     Exit,
-    Expression(Box<Expression>),
+    Expression(Expression),
 }
 
 enum Error {
@@ -89,11 +91,11 @@ fn parse_input(line: &str) -> Result<ParseResult, Error> {
         Term::F64(right.parse::<f64>().map_err(|_| Error::ParseError)?)
     };
 
-    Ok(ParseResult::Expression(Box::new(Expression {
+    Ok(ParseResult::Expression(Expression {
         left: left_term,
         op: operand,
         right: right_term,
-    })))
+    }))
 }
 
 fn encrypt_term(runtime: &Runtime, public_key: &PublicKey, input: Term) -> Term {
@@ -145,7 +147,7 @@ fn alice(
             let parsed = parse_input(line);
 
             let Expression { left, right, op } = match parsed {
-                Ok(ParseResult::Expression(val)) => *val,
+                Ok(ParseResult::Expression(val)) => val,
                 Ok(ParseResult::Exit) => std::process::exit(0),
                 Ok(ParseResult::Help) => {
                     help();

--- a/examples/chi_sq/src/main.rs
+++ b/examples/chi_sq/src/main.rs
@@ -11,6 +11,8 @@
 //! Sunscreen's results with other FHE compilers, see
 //! [SoK: Fully Homomorphic Encryption Compilers](https://arxiv.org/abs/2101.07078).
 
+#![allow(clippy::type_complexity)]
+
 use sunscreen::{
     fhe_program,
     types::{

--- a/examples/chi_sq/src/main.rs
+++ b/examples/chi_sq/src/main.rs
@@ -11,8 +11,6 @@
 //! Sunscreen's results with other FHE compilers, see
 //! [SoK: Fully Homomorphic Encryption Compilers](https://arxiv.org/abs/2101.07078).
 
-#![allow(clippy::type_complexity)]
-
 use sunscreen::{
     fhe_program,
     types::{

--- a/examples/dot_prod/src/main.rs
+++ b/examples/dot_prod/src/main.rs
@@ -169,7 +169,7 @@ fn main() -> Result<(), sunscreen::Error> {
     let (public_key, private_key) = runtime.generate_keys()?;
     let a_enc = runtime.encrypt(a_batched, &public_key)?;
 
-    let args: Vec<FheProgramInput> = vec![a_enc.clone().into(), a_enc.clone().into()];
+    let args: Vec<FheProgramInput> = vec![a_enc.clone().into(), a_enc.into()];
 
     // Run our dot product homomorphically, decrypt and verify the result.
     let start = Instant::now();

--- a/examples/mean_variance/src/main.rs
+++ b/examples/mean_variance/src/main.rs
@@ -15,8 +15,8 @@ where
 {
     let mut sum = data[0];
 
-    for i in 1..data.len() {
-        sum = sum + data[i];
+    for &x in data.iter().skip(1) {
+        sum = sum + x;
     }
 
     sum / (data.len() as f64)

--- a/examples/mean_variance/src/main.rs
+++ b/examples/mean_variance/src/main.rs
@@ -27,7 +27,7 @@ where
     T: Add<Output = T> + Sub<Output = T> + Mul<Output = T> + Div<f64, Output = T> + Copy,
 {
     let mean_data = mean(data);
-    let mut variance = data.clone();
+    let mut variance = *data;
 
     for i in 0..data.len() {
         let tmp = mean_data - data[i];

--- a/examples/pir/src/main.rs
+++ b/examples/pir/src/main.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_range_loop)]
+
 use sunscreen::{
     fhe_program,
     types::{bfv::Signed, Cipher},
@@ -73,9 +75,9 @@ impl Server {
         let mut database = [[Signed::from(0); SQRT_DATABASE_SIZE]; SQRT_DATABASE_SIZE];
         let mut val = Signed::from(400);
 
-        for i in 0..SQRT_DATABASE_SIZE {
-            for j in 0..SQRT_DATABASE_SIZE {
-                database[i][j] = val;
+        for row in database.iter_mut() {
+            for entry in row.iter_mut() {
+                *entry = val;
                 val = val + 1;
             }
         }

--- a/seal_fhe/build.rs
+++ b/seal_fhe/build.rs
@@ -1,5 +1,3 @@
-use bindgen;
-
 use cmake::Config;
 use emsdk::Config as EmConfig;
 
@@ -92,9 +90,9 @@ fn main() {
     };
 
     if target == "wasm32-unknown-emscripten" {
-        compile_wasm(&profile, &out_path);
+        compile_wasm(profile, &out_path);
     } else {
-        compile_native(&profile, &out_path);
+        compile_native(profile, &out_path);
     }
 
     let mut builder = bindgen::builder()

--- a/seal_fhe/src/bfv_evaluator.rs
+++ b/seal_fhe/src/bfv_evaluator.rs
@@ -25,7 +25,7 @@ impl BFVEvaluator {
      * * `ctx` - The context.
      */
     pub fn new(ctx: &Context) -> Result<BFVEvaluator> {
-        Ok(BFVEvaluator(EvaluatorBase::new(&ctx)?))
+        Ok(BFVEvaluator(EvaluatorBase::new(ctx)?))
     }
 }
 
@@ -259,7 +259,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus(PlainModulus::batching(8192, 32).unwrap())
             .build()
@@ -306,7 +306,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus(PlainModulus::batching(8192, 20).unwrap())
             .build()

--- a/seal_fhe/src/bfv_evaluator.rs
+++ b/seal_fhe/src/bfv_evaluator.rs
@@ -645,7 +645,7 @@ mod tests {
 
             let no_relin_noise = noise_before - decryptor.invariant_noise_budget(&a_c_2).unwrap();
 
-            assert_eq!(relin_noise < no_relin_noise, true)
+            assert!(relin_noise < no_relin_noise)
         });
     }
 
@@ -675,7 +675,7 @@ mod tests {
 
             let no_relin_noise = noise_before - decryptor.invariant_noise_budget(&a_c_2).unwrap();
 
-            assert_eq!(relin_noise < no_relin_noise, true)
+            assert!(relin_noise < no_relin_noise)
         });
     }
 

--- a/seal_fhe/src/context.rs
+++ b/seal_fhe/src/context.rs
@@ -103,7 +103,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(1024)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus_u64(1234)
             .build()

--- a/seal_fhe/src/encoder.rs
+++ b/seal_fhe/src/encoder.rs
@@ -119,7 +119,7 @@ impl BFVEncoder {
         Ok(plaintext)
     }
 
-    /**  
+    /**
      * Inverse of encode. This function "unbatches" a given plaintext into a matrix
      * of integers modulo the plaintext modulus, and stores the result in the destination
      * parameter. The input plaintext must have degrees less than the polynomial modulus,
@@ -157,7 +157,7 @@ impl BFVEncoder {
         Ok(data)
     }
 
-    /**  
+    /**
      * Inverse of encode. This function "unbatches" a given plaintext into a matrix
      * of integers modulo the plaintext modulus, and stores the result in the destination
      * parameter. The input plaintext must have degrees less than the polynomial modulus,
@@ -269,10 +269,16 @@ impl BFVScalarEncoder {
         convert_seal_error(unsafe { bindgen::Plaintext_CoeffCount(p.get_handle(), &mut len) })?;
 
         convert_seal_error(unsafe {
-            bindgen::Plaintext_CoeffAt(p.get_handle(), 0, std::mem::transmute(&mut coeff))
+            bindgen::Plaintext_CoeffAt(p.get_handle(), 0, &mut coeff as *mut i64 as *mut u64)
         })?;
 
         Ok(coeff)
+    }
+}
+
+impl Default for BFVScalarEncoder {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/seal_fhe/src/encoder.rs
+++ b/seal_fhe/src/encoder.rs
@@ -285,7 +285,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus(PlainModulus::batching(8192, 20).unwrap())
             .build()
@@ -303,7 +303,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus(PlainModulus::batching(8192, 20).unwrap())
             .build()
@@ -321,7 +321,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus(PlainModulus::batching(8192, 20).unwrap())
             .build()
@@ -348,7 +348,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus(PlainModulus::batching(8192, 20).unwrap())
             .build()

--- a/seal_fhe/src/encryption_parameters.rs
+++ b/seal_fhe/src/encryption_parameters.rs
@@ -310,6 +310,12 @@ impl BfvEncryptionParametersBuilder {
     }
 }
 
+impl Default for BfvEncryptionParametersBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Drop for EncryptionParameters {
     fn drop(&mut self) {
         unsafe { bindgen::EncParams_Destroy(self.handle) };

--- a/seal_fhe/src/encryption_parameters.rs
+++ b/seal_fhe/src/encryption_parameters.rs
@@ -341,7 +341,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(1024)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus_u64(1234)
             .build()

--- a/seal_fhe/src/encryptor_decryptor.rs
+++ b/seal_fhe/src/encryptor_decryptor.rs
@@ -250,7 +250,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus_u64(1234)
             .build()
@@ -271,7 +271,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus_u64(1234)
             .build()
@@ -294,7 +294,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus_u64(1234)
             .build()
@@ -314,7 +314,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus(PlainModulus::batching(8192, 20).unwrap())
             .build()
@@ -353,7 +353,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus(PlainModulus::batching(8192, 20).unwrap())
             .build()

--- a/seal_fhe/src/error.rs
+++ b/seal_fhe/src/error.rs
@@ -8,7 +8,7 @@ use crate::bindgen::{
 /**
  * A type representing all errors that can occur in SEAL.
  */
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Error {
     /// No error
     Ok,

--- a/seal_fhe/src/key_generator.rs
+++ b/seal_fhe/src/key_generator.rs
@@ -739,7 +739,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus_u64(1234)
             .build()
@@ -766,7 +766,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus_u64(1234)
             .build()
@@ -783,7 +783,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus_u64(1234)
             .build()
@@ -817,7 +817,7 @@ mod tests {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)
             .set_coefficient_modulus(
-                CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap(),
+                CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap(),
             )
             .set_plain_modulus_u64(1234)
             .build()

--- a/seal_fhe/src/modulus.rs
+++ b/seal_fhe/src/modulus.rs
@@ -42,7 +42,7 @@ impl PartialEq for Modulus {
  * Microsoft SEAL when constructing a SEALContext object. Normal users should not
  * have to specify the security level explicitly anywhere.
  */
-#[derive(Debug, Copy, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[repr(i32)]
 pub enum SecurityLevel {
     /// 128-bit security level according to HomomorphicEncryption.org standard.
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn can_create_custom_coefficient_modulus() {
-        let modulus = CoefficientModulus::create(8192, &vec![50, 30, 30, 50, 50]).unwrap();
+        let modulus = CoefficientModulus::create(8192, &[50, 30, 30, 50, 50]).unwrap();
 
         assert_eq!(modulus.len(), 5);
         assert_eq!(modulus[0].value(), 1125899905744897);

--- a/seal_fhe/src/modulus.rs
+++ b/seal_fhe/src/modulus.rs
@@ -71,9 +71,9 @@ impl TryFrom<i32> for SecurityLevel {
     }
 }
 
-impl Into<i32> for SecurityLevel {
-    fn into(self) -> i32 {
-        match self {
+impl From<SecurityLevel> for i32 {
+    fn from(val: SecurityLevel) -> Self {
+        match val {
             SecurityLevel::TC128 => 128,
             SecurityLevel::TC192 => 192,
             SecurityLevel::TC256 => 256,
@@ -169,7 +169,7 @@ impl CoefficientModulus {
      * PolyModulusDegree.The return value will be a vector consisting of
      * Modulus elements representing distinct prime numbers of bit-lengths
      * as given in the bitSizes parameter. The bit sizes of the prime numbers
-     * can be at most 60 bits.     
+     * can be at most 60 bits.
      */
     pub fn create(degree: u64, bit_sizes: &[i32]) -> Result<Vec<Modulus>> {
         let mut bit_sizes = bit_sizes.to_owned();
@@ -238,7 +238,7 @@ impl CoefficientModulus {
 
         unsafe { bindgen::CoeffModulus_MaxBitCount(degree, security_level as i32, &mut bits) };
 
-        assert_eq!(bits > 0, true);
+        assert!(bits > 0);
 
         bits as u32
     }

--- a/seal_fhe/src/plaintext_ciphertext.rs
+++ b/seal_fhe/src/plaintext_ciphertext.rs
@@ -253,6 +253,7 @@ impl Plaintext {
     /**
      * Returns the number of coefficients this plaintext can hold.
      */
+    #[allow(clippy::len_without_is_empty)]
     pub fn len(&self) -> usize {
         let mut size: u64 = 0;
 

--- a/seal_fhe/tests/assumptions.rs
+++ b/seal_fhe/tests/assumptions.rs
@@ -22,12 +22,12 @@ fn overflow_does_not_bleed_into_other_lanes() {
         let p_2 = decryptor.decrypt(&c_2).unwrap();
         let out = encoder.decode_unsigned(&p_2).unwrap();
 
-        for i in 0..out.len() {
+        for (i, lane) in out.into_iter().enumerate() {
             if i == 1 {
                 // This lane overflowed...
-                assert_eq!(out[i], 105_881);
+                assert_eq!(lane, 105_881);
             } else {
-                assert_eq!(out[i], 10_000);
+                assert_eq!(lane, 10_000);
             }
         }
     })
@@ -100,8 +100,8 @@ fn lanes_have_same_modulus() {
         let p_2 = decryptor.decrypt(&c_2).unwrap();
         let out = encoder.decode_unsigned(&p_2).unwrap();
 
-        for i in 0..out.len() {
-            assert_eq!(out[i], 105_881);
+        for lane in out {
+            assert_eq!(lane, 105_881);
         }
     })
 }
@@ -129,8 +129,8 @@ fn lane_modulus_is_not_power_of_2() {
         let p_2 = decryptor.decrypt(&c_2).unwrap();
         let out = encoder.decode_unsigned(&p_2).unwrap();
 
-        for i in 0..out.len() {
-            assert_eq!(out[i], 0);
+        for lane in out {
+            assert_eq!(lane, 0);
         }
     })
 }

--- a/sunscreen/src/compiler.rs
+++ b/sunscreen/src/compiler.rs
@@ -53,6 +53,12 @@ pub struct Compiler {
     noise_margin: u32,
 }
 
+impl Default for Compiler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Compiler {
     /**
      * Creates a new [`Compiler`] builder.

--- a/sunscreen/src/error.rs
+++ b/sunscreen/src/error.rs
@@ -1,4 +1,4 @@
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /**
  * Represents an error that can occur in this crate.
  */

--- a/sunscreen/src/lib.rs
+++ b/sunscreen/src/lib.rs
@@ -126,7 +126,7 @@ impl Application {
     /**
      * Gets the [`CompiledFheProgram`] with the given name or [`None`] if not present.
      */
-    pub fn get_program<'a, N>(&self, name: N) -> Option<&CompiledFheProgram>
+    pub fn get_program<N>(&self, name: N) -> Option<&CompiledFheProgram>
     where
         N: AsRef<str>,
     {
@@ -461,21 +461,14 @@ impl Context {
     pub fn add_literal(&mut self, literal: Literal) -> NodeIndex {
         // See if we already have a node for the given literal. If so, just return it.
         // If not, make a new one.
-        let existing_literal = self
-            .compilation
-            .graph
-            .node_indices()
-            .filter_map(|i| match &self.compilation.graph[i] {
-                Operation::Literal(x) => {
-                    if *x == literal {
-                        Some(i)
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            })
-            .next();
+        let existing_literal =
+            self.compilation
+                .graph
+                .node_indices()
+                .find(|&i| match &self.compilation.graph[i] {
+                    Operation::Literal(x) => *x == literal,
+                    _ => false,
+                });
 
         match existing_literal {
             Some(x) => x,

--- a/sunscreen/src/lib.rs
+++ b/sunscreen/src/lib.rs
@@ -106,7 +106,7 @@ impl Application {
      * It is an implementation detail of compilation.
      */
     pub(crate) fn new(programs: HashMap<String, CompiledFheProgram>) -> Result<Self> {
-        if programs.len() == 0 {
+        if programs.is_empty() {
             return Err(Error::NoPrograms);
         }
 
@@ -233,7 +233,7 @@ pub enum Operation {
     Output,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Eq)]
 /**
  * Information about an edge in the frontend IR.
  */
@@ -475,7 +475,7 @@ impl Context {
                 }
                 _ => None,
             })
-            .nth(0);
+            .next();
 
         match existing_literal {
             Some(x) => x,
@@ -563,7 +563,7 @@ impl FrontendCompilation {
             },
         );
 
-        fhe_program.graph = StableGraph::from(mapped_graph);
+        fhe_program.graph = mapped_graph;
 
         compile_inplace(fhe_program)
     }

--- a/sunscreen/src/params.rs
+++ b/sunscreen/src/params.rs
@@ -12,7 +12,7 @@ use sunscreen_backend::noise_model::{
 use sunscreen_fhe_program::{FheProgram, Operation, SchemeType};
 pub use sunscreen_runtime::Params;
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /**
  * A constraint on the plaintext
  */
@@ -84,7 +84,7 @@ fn can_make_required_keys(fhe_program: &FheProgram, params: &Params) -> Result<b
     let modulus_chain = params
         .coeff_modulus
         .iter()
-        .map(|x| Modulus::new(*x).map_err(|e| Error::from(e)))
+        .map(|x| Modulus::new(*x).map_err(Error::from))
         .collect::<Result<Vec<Modulus>>>()?;
 
     let enc_params = BfvEncryptionParametersBuilder::new()
@@ -147,8 +147,8 @@ pub fn determine_params(
             coeff_modulus: coeff.iter().map(|v| v.value()).collect(),
             lattice_dimension: *n,
             plain_modulus: plaintext_modulus.value(),
-            security_level: security_level,
-            scheme_type: scheme_type,
+            security_level,
+            scheme_type,
         };
 
         trace!(
@@ -163,7 +163,7 @@ pub fn determine_params(
             trace!("Running backend compilation for {}", program.name());
             let ir = program.build(&params)?.compile();
 
-            ir.validate().map_err(|e| Error::FheProgramError(e))?;
+            ir.validate().map_err(Error::FheProgramError)?;
             trace!("Built and validated {}", program.name());
 
             match can_make_required_keys(&ir, &params) {

--- a/sunscreen/src/types/bfv/batched.rs
+++ b/sunscreen/src/types/bfv/batched.rs
@@ -237,7 +237,7 @@ impl<const LANES: usize> TryFromPlaintext for Batched<LANES> {
                 row_0
                     .iter()
                     .take(LANES)
-                    .map(|x| *x)
+                    .copied()
                     .collect::<Vec<i64>>()
                     .try_into()
                     .map_err(|_| {
@@ -249,7 +249,7 @@ impl<const LANES: usize> TryFromPlaintext for Batched<LANES> {
                 row_1
                     .iter()
                     .take(LANES)
-                    .map(|x| *x)
+                    .copied()
                     .collect::<Vec<i64>>()
                     .try_into()
                     .map_err(|_| {
@@ -405,12 +405,12 @@ impl<const LANES: usize> Shl<u64> for Batched<LANES> {
             self.data[0]
                 .iter()
                 .skip(x as usize)
-                .map(|x| *x)
+                .copied()
                 .collect::<Vec<i64>>(),
             self.data[0]
                 .iter()
                 .take(x as usize)
-                .map(|x| *x)
+                .copied()
                 .collect::<Vec<i64>>(),
         ]
         .concat()
@@ -421,12 +421,12 @@ impl<const LANES: usize> Shl<u64> for Batched<LANES> {
             self.data[1]
                 .iter()
                 .skip(x as usize)
-                .map(|x| *x)
+                .copied()
                 .collect::<Vec<i64>>(),
             self.data[1]
                 .iter()
                 .take(x as usize)
-                .map(|x| *x)
+                .copied()
                 .collect::<Vec<i64>>(),
         ]
         .concat()
@@ -445,12 +445,12 @@ impl<const LANES: usize> Shr<u64> for Batched<LANES> {
             self.data[0]
                 .iter()
                 .skip(LANES - x as usize)
-                .map(|x| *x)
+                .copied()
                 .collect::<Vec<i64>>(),
             self.data[0]
                 .iter()
                 .take(LANES - x as usize)
-                .map(|x| *x)
+                .copied()
                 .collect::<Vec<i64>>(),
         ]
         .concat()
@@ -461,12 +461,12 @@ impl<const LANES: usize> Shr<u64> for Batched<LANES> {
             self.data[1]
                 .iter()
                 .skip(LANES - x as usize)
-                .map(|x| *x)
+                .copied()
                 .collect::<Vec<i64>>(),
             self.data[1]
                 .iter()
                 .take(LANES - x as usize)
-                .map(|x| *x)
+                .copied()
                 .collect::<Vec<i64>>(),
         ]
         .concat()
@@ -645,7 +645,7 @@ mod tests {
             security_level: SecurityLevel::TC128,
         };
 
-        let x = Batched::<4>::try_from(data.clone()).unwrap();
+        let x = Batched::<4>::try_from(data).unwrap();
 
         let plaintext = x.try_into_plaintext(&params).unwrap();
         let y = Batched::<4>::try_from_plaintext(&plaintext, &params).unwrap();

--- a/sunscreen/src/types/bfv/batched.rs
+++ b/sunscreen/src/types/bfv/batched.rs
@@ -280,9 +280,9 @@ impl<const LANES: usize> TryFrom<[Vec<i64>; 2]> for Batched<LANES> {
     }
 }
 
-impl<const LANES: usize> Into<[Vec<i64>; 2]> for Batched<LANES> {
-    fn into(self) -> [Vec<i64>; 2] {
-        [self.data[0].into(), self.data[1].into()]
+impl<const LANES: usize> From<Batched<LANES>> for [Vec<i64>; 2] {
+    fn from(val: Batched<LANES>) -> Self {
+        [val.data[0].into(), val.data[1].into()]
     }
 }
 
@@ -292,9 +292,9 @@ impl<const LANES: usize> From<[[i64; LANES]; 2]> for Batched<LANES> {
     }
 }
 
-impl<const LANES: usize> Into<[[i64; LANES]; 2]> for Batched<LANES> {
-    fn into(self) -> [[i64; LANES]; 2] {
-        [self.data[0], self.data[1]]
+impl<const LANES: usize> From<Batched<LANES>> for [[i64; LANES]; 2] {
+    fn from(val: Batched<LANES>) -> Self {
+        [val.data[0], val.data[1]]
     }
 }
 

--- a/sunscreen/src/types/bfv/fractional.rs
+++ b/sunscreen/src/types/bfv/fractional.rs
@@ -498,12 +498,10 @@ impl<const INT_BITS: usize> TryIntoPlaintext for Fractional<INT_BITS> {
 
             let coeff = if sign == 0 {
                 bit_value
+            } else if bit_value > 0 {
+                params.plain_modulus - bit_value
             } else {
-                if bit_value > 0 {
-                    params.plain_modulus - bit_value
-                } else {
-                    0
-                }
+                0
             };
 
             seal_plaintext.set_coefficient(coeff_index as usize, coeff);
@@ -732,9 +730,9 @@ mod tests {
         let b = Fractional::<64>::from(1.5);
 
         // Allow 1 ULP of error
-        assert!((a + b).approx_eq(4.64.into(), (0.0, 1)));
-        assert!((3.14 + b).approx_eq(4.64.into(), (0.0, 1)));
-        assert!((a + 1.5).approx_eq(4.64.into(), (0.0, 1)));
+        assert!((a + b).approx_eq(4.64, (0.0, 1)));
+        assert!((3.14 + b).approx_eq(4.64, (0.0, 1)));
+        assert!((a + 1.5).approx_eq(4.64, (0.0, 1)));
     }
 
     #[test]
@@ -743,9 +741,9 @@ mod tests {
         let b = Fractional::<64>::from(1.5);
 
         // Allow 1 ULP of error
-        assert!((a * b).approx_eq(4.71.into(), (0.0, 1)));
-        assert!((3.14 * b).approx_eq(4.71.into(), (0.0, 1)));
-        assert!((a * 1.5).approx_eq(4.71.into(), (0.0, 1)));
+        assert!((a * b).approx_eq(4.71, (0.0, 1)));
+        assert!((3.14 * b).approx_eq(4.71, (0.0, 1)));
+        assert!((a * 1.5).approx_eq(4.71, (0.0, 1)));
     }
 
     #[test]
@@ -754,9 +752,9 @@ mod tests {
         let b = Fractional::<64>::from(1.5);
 
         // Allow 1 ULP of error
-        assert!((a - b).approx_eq(1.64.into(), (0.0, 1)));
-        assert!((3.14 - b).approx_eq(1.64.into(), (0.0, 1)));
-        assert!((a - 1.5).approx_eq(1.64.into(), (0.0, 1)));
+        assert!((a - b).approx_eq(1.64, (0.0, 1)));
+        assert!((3.14 - b).approx_eq(1.64, (0.0, 1)));
+        assert!((a - 1.5).approx_eq(1.64, (0.0, 1)));
     }
 
     #[test]
@@ -764,7 +762,7 @@ mod tests {
         let a = Fractional::<64>::from(3.14);
 
         // Allow 1 ULP of error
-        assert!((a / 1.5).approx_eq((3.14 / 1.5).into(), (0.0, 1)));
+        assert!((a / 1.5).approx_eq(3.14 / 1.5, (0.0, 1)));
     }
 
     #[test]

--- a/sunscreen/src/types/bfv/fractional.rs
+++ b/sunscreen/src/types/bfv/fractional.rs
@@ -465,7 +465,7 @@ impl<const INT_BITS: usize> TryIntoPlaintext for Fractional<INT_BITS> {
 
         // Coerce the f64 into a u64 so we can extract out the
         // sign, mantissa, and exponent.
-        let as_u64: u64 = unsafe { std::mem::transmute(self.val) };
+        let as_u64: u64 = self.val.to_bits();
 
         let sign_mask = 0x1 << 63;
         let mantissa_mask = 0xFFFFFFFFFFFFF;
@@ -568,9 +568,9 @@ impl<const INT_BITS: usize> From<f64> for Fractional<INT_BITS> {
     }
 }
 
-impl<const INT_BITS: usize> Into<f64> for Fractional<INT_BITS> {
-    fn into(self) -> f64 {
-        self.val
+impl<const INT_BITS: usize> From<Fractional<INT_BITS>> for f64 {
+    fn from(frac: Fractional<INT_BITS>) -> Self {
+        frac.val
     }
 }
 
@@ -684,6 +684,9 @@ impl<const INT_BITS: usize> Neg for Fractional<INT_BITS> {
 
 #[cfg(test)]
 mod tests {
+
+    #![allow(clippy::approx_constant)]
+
     use super::*;
     use crate::{SchemeType, SecurityLevel};
     use float_cmp::ApproxEq;

--- a/sunscreen/src/types/bfv/rational.rs
+++ b/sunscreen/src/types/bfv/rational.rs
@@ -88,9 +88,8 @@ impl TryFrom<f64> for Rational {
     type Error = Error;
 
     fn try_from(val: f64) -> Result<Self, Self::Error> {
-        let val = Rational64::approximate_float(val).ok_or(Error::FheTypeError(
-            "Failed to parse float into rational".to_owned(),
-        ))?;
+        let val = Rational64::approximate_float(val)
+            .ok_or_else(|| Error::FheTypeError("Failed to parse float into rational".to_owned()))?;
 
         Ok(Self {
             num: Signed::from(*val.numer()),
@@ -99,10 +98,10 @@ impl TryFrom<f64> for Rational {
     }
 }
 
-impl Into<f64> for Rational {
-    fn into(self) -> f64 {
-        let num: i64 = self.num.into();
-        let den: i64 = self.den.into();
+impl From<Rational> for f64 {
+    fn from(val: Rational) -> Self {
+        let num: i64 = val.num.into();
+        let den: i64 = val.den.into();
 
         num as f64 / den as f64
     }

--- a/sunscreen/src/types/bfv/signed.rs
+++ b/sunscreen/src/types/bfv/signed.rs
@@ -137,9 +137,9 @@ impl From<i64> for Signed {
     }
 }
 
-impl Into<i64> for Signed {
-    fn into(self) -> i64 {
-        self.val
+impl From<Signed> for i64 {
+    fn from(signed: Signed) -> Self {
+        signed.val
     }
 }
 

--- a/sunscreen/src/types/intern/input.rs
+++ b/sunscreen/src/types/intern/input.rs
@@ -92,7 +92,7 @@ fn can_create_inputs() {
         let mut offset = 0;
 
         assert_eq!(scalar_node.ids.len(), 2);
-        assert_eq!(scalar_node.ids[0].index(), offset + 0);
+        assert_eq!(scalar_node.ids[0].index(), offset);
         assert_eq!(scalar_node.ids[1].index(), offset + 1);
 
         offset += 2;
@@ -103,7 +103,7 @@ fn can_create_inputs() {
 
         for i in 0..6 {
             assert_eq!(array_node[i].ids.len(), 2);
-            assert_eq!(array_node[i].ids[0].index(), offset + 2 * i + 0);
+            assert_eq!(array_node[i].ids[0].index(), offset + 2 * i);
             assert_eq!(array_node[i].ids[1].index(), offset + 2 * i + 1);
         }
 
@@ -117,7 +117,7 @@ fn can_create_inputs() {
                 assert_eq!(multi_dim_array_node[i][j].ids.len(), 2);
                 assert_eq!(
                     multi_dim_array_node[i][j].ids[0].index(),
-                    offset + 6 * 2 * i + 2 * j + 0
+                    offset + 6 * 2 * i + 2 * j
                 );
                 assert_eq!(
                     multi_dim_array_node[i][j].ids[1].index(),

--- a/sunscreen/src/types/intern/input.rs
+++ b/sunscreen/src/types/intern/input.rs
@@ -101,10 +101,10 @@ fn can_create_inputs() {
 
         assert_eq!(array_node.len(), 6);
 
-        for i in 0..6 {
-            assert_eq!(array_node[i].ids.len(), 2);
-            assert_eq!(array_node[i].ids[0].index(), offset + 2 * i);
-            assert_eq!(array_node[i].ids[1].index(), offset + 2 * i + 1);
+        for (i, node) in array_node.into_iter().enumerate() {
+            assert_eq!(node.ids.len(), 2);
+            assert_eq!(node.ids[0].index(), offset + 2 * i);
+            assert_eq!(node.ids[1].index(), offset + 2 * i + 1);
         }
 
         let multi_dim_array_node: [[FheProgramNode<Cipher<Rational>>; 6]; 6] =
@@ -112,17 +112,11 @@ fn can_create_inputs() {
 
         offset += 12;
 
-        for i in 0..6 {
-            for j in 0..6 {
-                assert_eq!(multi_dim_array_node[i][j].ids.len(), 2);
-                assert_eq!(
-                    multi_dim_array_node[i][j].ids[0].index(),
-                    offset + 6 * 2 * i + 2 * j
-                );
-                assert_eq!(
-                    multi_dim_array_node[i][j].ids[1].index(),
-                    offset + 6 * 2 * i + 2 * j + 1
-                );
+        for (i, row) in multi_dim_array_node.into_iter().enumerate() {
+            for (j, entry) in row.into_iter().enumerate() {
+                assert_eq!(entry.ids.len(), 2);
+                assert_eq!(entry.ids[0].index(), offset + 6 * 2 * i + 2 * j);
+                assert_eq!(entry.ids[1].index(), offset + 6 * 2 * i + 2 * j + 1);
             }
         }
 

--- a/sunscreen/src/types/intern/u64_literal.rs
+++ b/sunscreen/src/types/intern/u64_literal.rs
@@ -12,7 +12,7 @@ impl U64LiteralRef {
      * Creates a reference to the given literal. If the given literal already exists in the current
      * graph, a reference to the existing literal is returned.
      */
-    pub fn new(val: u64) -> NodeIndex {
+    pub fn node(val: u64) -> NodeIndex {
         with_ctx(|ctx| ctx.add_literal(Literal::U64(val)))
     }
 }

--- a/sunscreen/tests/array.rs
+++ b/sunscreen/tests/array.rs
@@ -194,7 +194,7 @@ fn cipher_plain_arrays() {
 fn can_mutate_array() {
     #[fhe_program(scheme = "bfv")]
     fn mult(mut a: [Cipher<Signed>; 6]) -> Cipher<Signed> {
-        let mut a = a.clone();
+        let mut a = a;
 
         for i in 0..a.len() {
             a[i] = a[i] * 2
@@ -241,7 +241,7 @@ fn can_mutate_array() {
 fn can_return_array() {
     #[fhe_program(scheme = "bfv")]
     fn mult(mut a: [Cipher<Signed>; 6]) -> [Cipher<Signed>; 6] {
-        let mut a = a.clone();
+        let mut a = a;
 
         for i in 0..a.len() {
             a[i] = a[i] * 2

--- a/sunscreen/tests/array.rs
+++ b/sunscreen/tests/array.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::needless_range_loop)]
+
 use sunscreen::{
     fhe_program,
     types::{bfv::Signed, Cipher},

--- a/sunscreen/tests/fhe_program_tests.rs
+++ b/sunscreen/tests/fhe_program_tests.rs
@@ -92,7 +92,7 @@ fn capture_fhe_program_input_args() {
             type_name.clone(),
             type_name.clone(),
             type_name.clone(),
-            type_name.clone(),
+            type_name,
         ],
         returns: vec![],
         num_ciphertexts: vec![],
@@ -115,7 +115,7 @@ fn can_add() {
     let type_name = Cipher::<Signed>::type_name();
 
     let expected_signature = CallSignature {
-        arguments: vec![type_name.clone(), type_name.clone(), type_name.clone()],
+        arguments: vec![type_name.clone(), type_name.clone(), type_name],
         returns: vec![],
         num_ciphertexts: vec![],
     };
@@ -225,7 +225,7 @@ fn can_mul() {
     let type_name = Cipher::<Signed>::type_name();
 
     let expected_signature = CallSignature {
-        arguments: vec![type_name.clone(), type_name.clone(), type_name.clone()],
+        arguments: vec![type_name.clone(), type_name.clone(), type_name],
         returns: vec![],
         num_ciphertexts: vec![],
     };
@@ -287,7 +287,7 @@ fn can_collect_output() {
 
     let expected_signature = CallSignature {
         arguments: vec![type_name.clone(), type_name.clone()],
-        returns: vec![type_name.clone()],
+        returns: vec![type_name],
         num_ciphertexts: vec![1],
     };
     assert_eq!(fhe_program_with_args.signature(), expected_signature);
@@ -356,7 +356,7 @@ fn can_collect_multiple_outputs() {
 
     let expected_signature = CallSignature {
         arguments: vec![type_name.clone(), type_name.clone()],
-        returns: vec![type_name.clone(), type_name.clone()],
+        returns: vec![type_name.clone(), type_name],
         num_ciphertexts: vec![1, 1],
     };
     assert_eq!(fhe_program_with_args.signature(), expected_signature);

--- a/sunscreen/tests/fhe_program_tests.rs
+++ b/sunscreen/tests/fhe_program_tests.rs
@@ -49,7 +49,7 @@ fn panicing_fhe_program_clears_ctx() {
         CURRENT_CTX.with(|ctx| {
             let old = ctx.take();
 
-            assert_eq!(old.is_some(), true);
+            assert!(old.is_some());
             ctx.replace(old);
         });
 
@@ -69,12 +69,12 @@ fn panicing_fhe_program_clears_ctx() {
         let _context = panic_fhe_program.build(&get_params()).unwrap();
     });
 
-    assert_eq!(panic_result.is_err(), true);
+    assert!(panic_result.is_err());
 
     CURRENT_CTX.with(|ctx| {
         let old = ctx.take();
 
-        assert_eq!(old.is_none(), true);
+        assert!(old.is_none());
     });
 }
 

--- a/sunscreen/tests/fractional.rs
+++ b/sunscreen/tests/fractional.rs
@@ -69,12 +69,12 @@ fn can_add() {
             .run(app.get_program(add_c_c).unwrap(), args, &public_key)
             .unwrap();
 
-        let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_p.clone().into()];
+        let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_p.into()];
         let c_1 = runtime
             .run(app.get_program(add_c_p).unwrap(), args, &public_key)
             .unwrap();
 
-        let args: Vec<FheProgramInput> = vec![a_p.clone().into(), b_c.clone().into()];
+        let args: Vec<FheProgramInput> = vec![a_p.into(), b_c.clone().into()];
         let c_2 = runtime
             .run(app.get_program(add_p_c).unwrap(), args, &public_key)
             .unwrap();
@@ -84,7 +84,7 @@ fn can_add() {
             .run(app.get_program(add_c_l).unwrap(), args, &public_key)
             .unwrap();
 
-        let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_c.clone().into()];
+        let args: Vec<FheProgramInput> = vec![a_c.into(), b_c.into()];
         let c_4 = runtime
             .run(app.get_program(add_l_c).unwrap(), args, &public_key)
             .unwrap();
@@ -95,11 +95,11 @@ fn can_add() {
         let c_3: Fractional<64> = runtime.decrypt(&c_3[0], &private_key).unwrap();
         let c_4: Fractional<64> = runtime.decrypt(&c_4[0], &private_key).unwrap();
 
-        assert!(c_0.approx_eq((add_fn(a, b)).into(), (0.0, 1)));
-        assert!(c_1.approx_eq((add_fn(a, b)).into(), (0.0, 1)));
-        assert!(c_2.approx_eq((add_fn(a, b)).into(), (0.0, 1)));
-        assert!(c_3.approx_eq((add_fn(a, 3.14)).into(), (0.0, 1)));
-        assert!(c_4.approx_eq((add_fn(3.14, a)).into(), (0.0, 1)));
+        assert!(c_0.approx_eq(add_fn(a, b), (0.0, 1)));
+        assert!(c_1.approx_eq(add_fn(a, b), (0.0, 1)));
+        assert!(c_2.approx_eq(add_fn(a, b), (0.0, 1)));
+        assert!(c_3.approx_eq(add_fn(a, 3.14), (0.0, 1)));
+        assert!(c_4.approx_eq(add_fn(3.14, a), (0.0, 1)));
     };
 
     do_add(3.14, 3.14);
@@ -175,12 +175,12 @@ fn can_mul() {
             .run(app.get_program(mul_c_c).unwrap(), args, &public_key)
             .unwrap();
 
-        let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_p.clone().into()];
+        let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_p.into()];
         let c_1 = runtime
             .run(app.get_program(mul_c_p).unwrap(), args, &public_key)
             .unwrap();
 
-        let args: Vec<FheProgramInput> = vec![a_p.clone().into(), b_c.clone().into()];
+        let args: Vec<FheProgramInput> = vec![a_p.into(), b_c.into()];
         let c_2 = runtime
             .run(app.get_program(mul_p_c).unwrap(), args, &public_key)
             .unwrap();
@@ -190,7 +190,7 @@ fn can_mul() {
             .run(app.get_program(mul_c_l).unwrap(), args, &public_key)
             .unwrap();
 
-        let args: Vec<FheProgramInput> = vec![a_c.clone().into()];
+        let args: Vec<FheProgramInput> = vec![a_c.into()];
         let c_4 = runtime
             .run(app.get_program(mul_l_c).unwrap(), args, &public_key)
             .unwrap();
@@ -222,11 +222,11 @@ fn can_mul() {
         let c_3: Fractional<64> = runtime.decrypt(&c_3[0], &private_key).unwrap();
         let c_4: Fractional<64> = runtime.decrypt(&c_4[0], &private_key).unwrap();
 
-        assert!(c_0.approx_eq(mul_fn(a, b).into(), (0.0, 1)));
-        assert!(c_1.approx_eq(mul_fn(a, b).into(), (0.0, 1)));
-        assert!(c_2.approx_eq(mul_fn(a, b).into(), (0.0, 1)));
-        assert!(c_3.approx_eq(mul_fn(a, 3.14).into(), (0.0, 1)));
-        assert!(c_4.approx_eq(mul_fn(3.14, a).into(), (0.0, 1)));
+        assert!(c_0.approx_eq(mul_fn(a, b), (0.0, 1)));
+        assert!(c_1.approx_eq(mul_fn(a, b), (0.0, 1)));
+        assert!(c_2.approx_eq(mul_fn(a, b), (0.0, 1)));
+        assert!(c_3.approx_eq(mul_fn(a, 3.14), (0.0, 1)));
+        assert!(c_4.approx_eq(mul_fn(3.14, a), (0.0, 1)));
     };
 
     do_mul(3.14, 3.14);
@@ -301,12 +301,12 @@ fn can_sub() {
             .run(app.get_program(sub_c_c).unwrap(), args, &public_key)
             .unwrap();
 
-        let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_p.clone().into()];
+        let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_p.into()];
         let c_1 = runtime
             .run(app.get_program(sub_c_p).unwrap(), args, &public_key)
             .unwrap();
 
-        let args: Vec<FheProgramInput> = vec![a_p.clone().into(), b_c.clone().into()];
+        let args: Vec<FheProgramInput> = vec![a_p.into(), b_c.clone().into()];
         let c_2 = runtime
             .run(app.get_program(sub_p_c).unwrap(), args, &public_key)
             .unwrap();
@@ -316,7 +316,7 @@ fn can_sub() {
             .run(app.get_program(sub_c_l).unwrap(), args, &public_key)
             .unwrap();
 
-        let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_c.clone().into()];
+        let args: Vec<FheProgramInput> = vec![a_c.into(), b_c.into()];
         let c_4 = runtime
             .run(app.get_program(sub_l_c).unwrap(), args, &public_key)
             .unwrap();
@@ -327,11 +327,11 @@ fn can_sub() {
         let c_3: Fractional<64> = runtime.decrypt(&c_3[0], &private_key).unwrap();
         let c_4: Fractional<64> = runtime.decrypt(&c_4[0], &private_key).unwrap();
 
-        assert!(c_0.approx_eq((sub_fn(a, b)).into(), (0.0, 1)));
-        assert!(c_1.approx_eq((sub_fn(a, b)).into(), (0.0, 1)));
-        assert!(c_2.approx_eq((sub_fn(a, b)).into(), (0.0, 1)));
-        assert!(c_3.approx_eq((sub_fn(a, 3.14)).into(), (0.0, 1)));
-        assert!(c_4.approx_eq((sub_fn(3.14, a)).into(), (0.0, 1)));
+        assert!(c_0.approx_eq(sub_fn(a, b), (0.0, 1)));
+        assert!(c_1.approx_eq(sub_fn(a, b), (0.0, 1)));
+        assert!(c_2.approx_eq(sub_fn(a, b), (0.0, 1)));
+        assert!(c_3.approx_eq(sub_fn(a, 3.14), (0.0, 1)));
+        assert!(c_4.approx_eq(sub_fn(3.14, a), (0.0, 1)));
     };
 
     do_sub(3.14, 3.14);

--- a/sunscreen/tests/fractional.rs
+++ b/sunscreen/tests/fractional.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::approx_constant)]
+
 use float_cmp::ApproxEq;
 use sunscreen::{
     fhe_program,
@@ -378,7 +380,7 @@ fn can_div_cipher_const() {
 
         let c: Fractional<64> = runtime.decrypt(&result[0], &private_key).unwrap();
 
-        assert!(c.approx_eq((a / 3.14).try_into().unwrap(), (0.0, 1)));
+        assert!(c.approx_eq(a / 3.14, (0.0, 1)));
     };
 
     test_div(-3.14);

--- a/sunscreen/tests/multi_program.rs
+++ b/sunscreen/tests/multi_program.rs
@@ -46,10 +46,10 @@ fn can_reference_program_strongly_or_stringly() {
     assert_eq!(mul.name(), "mul");
     assert_eq!(add.name(), "add");
 
-    assert_eq!(app.get_program(mul).is_some(), true);
-    assert_eq!(app.get_program("mul").is_some(), true);
-    assert_eq!(app.get_program(add).is_some(), true);
-    assert_eq!(app.get_program("add").is_some(), true);
+    assert!(app.get_program(mul).is_some());
+    assert!(app.get_program("mul").is_some());
+    assert!(app.get_program(add).is_some());
+    assert!(app.get_program("add").is_some());
 }
 
 #[test]
@@ -71,8 +71,8 @@ fn get_programs_iterates_every_program() {
         .unwrap();
 
     assert_eq!(app.get_programs().count(), 2);
-    assert_eq!(app.get_programs().any(|(k, _)| k == "mul"), true);
-    assert_eq!(app.get_programs().any(|(k, _)| k == "add"), true);
+    assert!(app.get_programs().any(|(k, _)| k == "mul"));
+    assert!(app.get_programs().any(|(k, _)| k == "add"));
 }
 
 #[test]

--- a/sunscreen/tests/rational.rs
+++ b/sunscreen/tests/rational.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::approx_constant)]
+
 use sunscreen::{
     fhe_program,
     types::{bfv::Rational, Cipher},

--- a/sunscreen/tests/simd.rs
+++ b/sunscreen/tests/simd.rs
@@ -153,7 +153,7 @@ fn can_add_cipher_cipher() {
         .compile()
         .unwrap();
 
-    let runtime = Runtime::new(&app.params()).unwrap();
+    let runtime = Runtime::new(app.params()).unwrap();
 
     let (public_key, private_key) = runtime.generate_keys().unwrap();
 
@@ -204,7 +204,7 @@ fn can_sub_cipher_cipher() {
 
     let a = Batched::<4>::try_from(data.clone()).unwrap();
     let a_c = runtime.encrypt(a, &public_key).unwrap();
-    let b = Batched::<4>::try_from(data.clone()).unwrap();
+    let b = Batched::<4>::try_from(data).unwrap();
     let b_c = runtime.encrypt(b, &public_key).unwrap();
 
     let args: Vec<FheProgramInput> = vec![a_c.into(), b_c.into()];
@@ -288,7 +288,7 @@ fn can_neg_cipher_cipher() {
 
     let data = [vec![1, 2, 3, 4], vec![5, 6, 7, 8]];
 
-    let a = Batched::<4>::try_from(data.clone()).unwrap();
+    let a = Batched::<4>::try_from(data).unwrap();
     let a_c = runtime.encrypt(a, &public_key).unwrap();
 
     let args: Vec<FheProgramInput> = vec![a_c.into()];

--- a/sunscreen/tests/typename_tests.rs
+++ b/sunscreen/tests/typename_tests.rs
@@ -4,6 +4,7 @@ use sunscreen::{
 };
 
 #[test]
+#[allow(clippy::blacklisted_name)]
 fn derive_typename_example() {
     #[derive(DeriveTypeName)]
     struct Foo {

--- a/sunscreen_backend/src/error.rs
+++ b/sunscreen_backend/src/error.rs
@@ -1,7 +1,7 @@
 use seal_fhe::Error as SealError;
 use sunscreen_runtime::FheProgramRunFailure as RuntimeError;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /**
  * Represents an error that can occur in this crate.
  */

--- a/sunscreen_backend/src/noise_model/canonical_embedding_norm.rs
+++ b/sunscreen_backend/src/noise_model/canonical_embedding_norm.rs
@@ -35,7 +35,7 @@ impl CanonicalEmbeddingNormModel {
      * * have a plain modulus < 2
      */
     pub fn new(params: &Params) -> Result<Self> {
-        if params.coeff_modulus.len() < 1 {
+        if params.coeff_modulus.is_empty() {
             return Err(Error::InvalidParams);
         }
 
@@ -87,9 +87,7 @@ impl NoiseModel for CanonicalEmbeddingNormModel {
         let noise = t * (n * (t - 1f64) / 2f64)
             + 2f64 * super::NOISE_STD_DEV * f64::sqrt(12f64 * n * n + 9f64 * n);
 
-        let invariant_noise = noise / q;
-
-        invariant_noise
+        noise / q
     }
 
     fn add_ct_ct(&self, a_invariant_noise: f64, b_invariant_noise: f64) -> f64 {

--- a/sunscreen_backend/src/noise_model/canonical_embedding_norm.rs
+++ b/sunscreen_backend/src/noise_model/canonical_embedding_norm.rs
@@ -232,7 +232,7 @@ mod tests {
                 let modeled_noise_budget =
                     crate::noise_model::noise_to_noise_budget(modeled_noise) as u32;
 
-                assert_eq!(modeled_noise_budget < measured_noise_budget, true);
+                assert!(modeled_noise_budget < measured_noise_budget);
             }
         }
     }
@@ -273,7 +273,7 @@ mod tests {
                 let modeled_noise_budget =
                     crate::noise_model::noise_to_noise_budget(s_noise) as u32;
 
-                assert_eq!(modeled_noise_budget < measured_noise_budget, true);
+                assert!(modeled_noise_budget < measured_noise_budget);
             }
         }
     }
@@ -312,7 +312,7 @@ mod tests {
                 let modeled_noise_budget =
                     crate::noise_model::noise_to_noise_budget(s_noise) as u32;
 
-                assert_eq!(modeled_noise_budget < measured_noise_budget, true);
+                assert!(modeled_noise_budget < measured_noise_budget);
             }
         }
     }
@@ -368,7 +368,7 @@ mod tests {
                     .checked_sub(post_multiply_modeled_noise)
                     .unwrap();
 
-                assert_eq!(modeled_noise > actual_noise, true);
+                assert!(modeled_noise > actual_noise);
             }
         }
     }
@@ -420,7 +420,7 @@ mod tests {
                     .checked_sub(measured_noise_budget)
                     .unwrap();
 
-                assert_eq!(modeled_noise > actual_noise, true);
+                assert!(modeled_noise > actual_noise);
             }
         }
     }

--- a/sunscreen_backend/src/noise_model/measured_model.rs
+++ b/sunscreen_backend/src/noise_model/measured_model.rs
@@ -273,10 +273,11 @@ fn create_inputs_for_program(
     // multiplying plaintexts.
     ir.graph
         .node_weights()
-        .filter(|n| match n.operation {
-            Operation::InputCiphertext(_) => true,
-            Operation::InputPlaintext(_) => true,
-            _ => false,
+        .filter(|n| {
+            matches!(
+                n.operation,
+                Operation::InputCiphertext(_) | Operation::InputPlaintext(_)
+            )
         })
         .zip(noise_targets)
         .map(|(n, target)| match n.operation {

--- a/sunscreen_backend/src/noise_model/measured_model.rs
+++ b/sunscreen_backend/src/noise_model/measured_model.rs
@@ -61,7 +61,7 @@ pub fn create_ciphertext_with_noise_level(
 ) -> Result<Ciphertext> {
     let encoder = BFVScalarEncoder::new();
 
-    let encryptor = Encryptor::with_public_and_secret_key(&context, &public_key, &private_key)?;
+    let encryptor = Encryptor::with_public_and_secret_key(context, public_key, private_key)?;
 
     let target_noise_level = match noise_level {
         TargetNoiseLevel::Fresh => {
@@ -80,8 +80,8 @@ pub fn create_ciphertext_with_noise_level(
         target_noise_level
     );
 
-    let decryptor = Decryptor::new(&context, &private_key)?;
-    let evaluator = BFVEvaluator::new(&context)?;
+    let decryptor = Decryptor::new(context, private_key)?;
+    let evaluator = BFVEvaluator::new(context)?;
 
     let p = encoder.encode_unsigned(1)?;
     let c_initial = encryptor.encrypt(&p)?;
@@ -271,8 +271,7 @@ fn create_inputs_for_program(
     // is meaningful or not. Just run a bunch of 1 values through the fhe_program and measure the
     // noise. We choose 1, as it avoids transparent ciphertexts when
     // multiplying plaintexts.
-    Ok(ir
-        .graph
+    ir.graph
         .node_weights()
         .filter(|n| match n.operation {
             Operation::InputCiphertext(_) => true,
@@ -292,7 +291,7 @@ fn create_inputs_for_program(
             Operation::InputPlaintext(_) => Ok(encoder.encode_unsigned(1)?.into()),
             _ => unreachable!(),
         })
-        .collect::<Result<Vec<SealData>>>()?)
+        .collect::<Result<Vec<SealData>>>()
 }
 
 fn make_relin_galois_keys(
@@ -366,7 +365,7 @@ impl MeasuredModel {
         // run_program_unchecked
         let outputs = unsafe {
             run_program_unchecked(
-                &ir,
+                ir,
                 &inputs,
                 &evaluator,
                 &relin_keys.as_ref(),
@@ -377,7 +376,7 @@ impl MeasuredModel {
         let mut noise_levels = vec![];
 
         for (i, o) in outputs.iter().enumerate() {
-            let invariant_noise = decryptor.invariant_noise(&o).unwrap();
+            let invariant_noise = decryptor.invariant_noise(o).unwrap();
 
             // The model expects noise budgets to be in terms of invariant
             // noise, not the budget.

--- a/sunscreen_backend/src/noise_model/mod.rs
+++ b/sunscreen_backend/src/noise_model/mod.rs
@@ -34,7 +34,7 @@ pub const NOISE_MAX: f64 = NOISE_STD_DEV * NOISE_NUM_STD_DEVIATIONS;
  * Panics if the FHE program is not well formed. You should call
  * validate before using this function to ascertain this.
  */
-pub fn predict_noise(model: &Box<dyn NoiseModel + Sync>, fhe_program: &FheProgram) -> Vec<f64> {
+pub fn predict_noise(model: &(dyn NoiseModel + Sync), fhe_program: &FheProgram) -> Vec<f64> {
     let mut noise_levels: Vec<AtomicCell<f64>> = Vec::with_capacity(fhe_program.graph.node_count());
 
     for _ in 0..fhe_program.graph.node_count() {

--- a/sunscreen_backend/src/transforms/insert_relinearizations.rs
+++ b/sunscreen_backend/src/transforms/insert_relinearizations.rs
@@ -64,36 +64,24 @@ mod tests {
         let relin_nodes = ir
             .graph
             .node_indices()
-            .filter(|i| match query.get_node(*i).operation {
-                Operation::Relinearize => true,
-                _ => false,
-            })
+            .filter(|i| matches!(query.get_node(*i).operation, Operation::Relinearize))
             .collect::<Vec<NodeIndex>>();
 
         // Should have 2 relin nodes added.
         assert_eq!(relin_nodes.len(), 2);
 
         // Every relin should have 1 predacessor.
-        assert_eq!(
-            relin_nodes
-                .iter()
-                .all(|id| { query.neighbors_directed(*id, Direction::Incoming).count() == 1 }),
-            true
-        );
+        assert!(relin_nodes
+            .iter()
+            .all(|id| { query.neighbors_directed(*id, Direction::Incoming).count() == 1 }),);
 
         // Every relin's predacessor should be a multiply
-        assert_eq!(
-            relin_nodes.iter().all(|id| {
-                query
-                    .neighbors_directed(*id, Direction::Incoming)
-                    .map(|id| query.get_node(id))
-                    .all(|node| match node.operation {
-                        Operation::Multiply => true,
-                        _ => false,
-                    })
-            }),
-            true
-        );
+        assert!(relin_nodes.iter().all(|id| {
+            query
+                .neighbors_directed(*id, Direction::Incoming)
+                .map(|id| query.get_node(id))
+                .all(|node| matches!(node.operation, Operation::Multiply))
+        }));
 
         // The first relin node should point to add_2
         assert_eq!(
@@ -112,16 +100,8 @@ mod tests {
         );
 
         // The first relin node should point to add_2
-        assert_eq!(
-            query
-                .neighbors_directed(relin_nodes[0], Direction::Outgoing)
-                .all(|i| {
-                    match query.get_node(i).operation {
-                        Operation::Add => true,
-                        _ => false,
-                    }
-                }),
-            true
-        );
+        assert!(query
+            .neighbors_directed(relin_nodes[0], Direction::Outgoing)
+            .all(|i| { matches!(query.get_node(i).operation, Operation::Add) }),);
     }
 }

--- a/sunscreen_compiler_macros/src/fhe_program.rs
+++ b/sunscreen_compiler_macros/src/fhe_program.rs
@@ -30,7 +30,7 @@ pub fn fhe_program_impl(
 
     let chain_count = attr_params.chain_count;
 
-    let unwrapped_inputs = match extract_fn_arguments(&inputs) {
+    let unwrapped_inputs = match extract_fn_arguments(inputs) {
         Ok(v) => v,
         Err(e) => {
             return proc_macro::TokenStream::from(match e {
@@ -77,7 +77,7 @@ pub fn fhe_program_impl(
 
     let fhe_program_returns = match return_types
         .iter()
-        .map(|t| map_fhe_type(t))
+        .map(map_fhe_type)
         .collect::<Result<Vec<Type>, MapFheTypeError>>()
     {
         Ok(v) => v,
@@ -111,7 +111,7 @@ pub fn fhe_program_impl(
 
     let fhe_program_name_literal = format!("{}", fhe_program_name);
 
-    let fhe_program = proc_macro::TokenStream::from(quote! {
+    proc_macro::TokenStream::from(quote! {
         #[allow(non_camel_case_types)]
         #[derive(Clone)]
         #vis struct #fhe_program_struct_name {
@@ -201,7 +201,5 @@ pub fn fhe_program_impl(
         #vis const #fhe_program_name: #fhe_program_struct_name = #fhe_program_struct_name {
             chain_count: #chain_count
         };
-    });
-
-    fhe_program
+    })
 }

--- a/sunscreen_compiler_macros/src/fhe_program.rs
+++ b/sunscreen_compiler_macros/src/fhe_program.rs
@@ -132,6 +132,7 @@ pub fn fhe_program_impl(
                 let mut context = Context::new(params);
 
                 CURRENT_CTX.with(|ctx| {
+                    #[allow(clippy::type_complexity)]
                     #[forbid(unused_variables)]
                     let internal = | #(#fhe_program_args)* | -> #fhe_program_return
                         #body

--- a/sunscreen_compiler_macros/src/fhe_program_transforms.rs
+++ b/sunscreen_compiler_macros/src/fhe_program_transforms.rs
@@ -126,7 +126,7 @@ impl From<MapFheTypeError> for ExtractReturnTypesError {
 pub fn extract_return_types(ret: &ReturnType) -> Result<Vec<Type>, ExtractReturnTypesError> {
     let return_types = match ret {
         ReturnType::Type(_, t) => match &**t {
-            Type::Tuple(t) => t.elems.iter().map(|x| x.clone()).collect::<Vec<Type>>(),
+            Type::Tuple(t) => t.elems.iter().cloned().collect::<Vec<Type>>(),
             Type::Paren(t) => {
                 vec![*t.elem.clone()]
             }

--- a/sunscreen_compiler_macros/src/internals/attr.rs
+++ b/sunscreen_compiler_macros/src/internals/attr.rs
@@ -169,7 +169,7 @@ impl Parse for Attrs {
             .unwrap_or(Ok(1))?;
 
         Ok(Self {
-            scheme: Scheme::parse(&scheme_type).map_err(|_e| {
+            scheme: Scheme::parse(scheme_type).map_err(|_e| {
                 Error::new_spanned(vars, format!("Unknown scheme '{}'", &scheme_type))
             })?,
             chain_count,

--- a/sunscreen_compiler_macros/src/internals/attr.rs
+++ b/sunscreen_compiler_macros/src/internals/attr.rs
@@ -104,7 +104,7 @@ impl Parse for Attrs {
                 Expr::Assign(a) => {
                     let key = match &*a.left {
                         Expr::Path(p) =>
-                            p.path.get_ident().ok_or(Error::new_spanned(p, "Key should contain only a single path element (e.g, foo, not foo::bar)".to_owned()))?.to_string(),
+                            p.path.get_ident().ok_or_else(||Error::new_spanned(p, "Key should contain only a single path element (e.g, foo, not foo::bar)".to_owned()))?.to_string(),
                         _ => { return Err(Error::new_spanned(&a.left, "Key should be a plain identifier")) }
                     };
 
@@ -137,7 +137,7 @@ impl Parse for Attrs {
                     let key = p
                         .path
                         .get_ident()
-                        .ok_or(Error::new_spanned(p, "Unknown identifier"))?
+                        .ok_or_else(|| Error::new_spanned(p, "Unknown identifier"))?
                         .to_string();
 
                     if !VALUE_KEYS.iter().any(|x| *x == key) {
@@ -157,10 +157,7 @@ impl Parse for Attrs {
 
         let scheme_type = attrs
             .get("scheme")
-            .ok_or(Error::new_spanned(
-                &vars,
-                "required `scheme` is missing".to_owned(),
-            ))?
+            .ok_or_else(|| Error::new_spanned(&vars, "required `scheme` is missing".to_owned()))?
             .as_str()?;
 
         let chain_count = attrs

--- a/sunscreen_compiler_macros/src/internals/case.rs
+++ b/sunscreen_compiler_macros/src/internals/case.rs
@@ -1,7 +1,7 @@
 use self::Scheme::*;
 use crate::error::*;
 
-#[derive(Copy, Clone, PartialEq)]
+#[derive(Copy, Clone, PartialEq, Eq)]
 pub enum Scheme {
     Bfv,
 }

--- a/sunscreen_compiler_macros/src/type_name.rs
+++ b/sunscreen_compiler_macros/src/type_name.rs
@@ -5,14 +5,12 @@ use syn::{parse_macro_input, DeriveInput, Ident, LitStr};
 pub fn derive_typename(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
-    let out = derive_typename_inner(input).into();
-
-    out
+    derive_typename_inner(input).into()
 }
 
 fn derive_typename_inner(parse_stream: DeriveInput) -> TokenStream {
     let name = &parse_stream.ident;
-    let name_contents = LitStr::new(&format!("{{}}::{}", name.to_string()), name.span());
+    let name_contents = LitStr::new(&format!("{{}}::{}", name), name.span());
     let crate_name = std::env::var("CARGO_CRATE_NAME").unwrap();
 
     // If the sunscreen crate itself tries to derive types, then it needs to refer
@@ -23,7 +21,7 @@ fn derive_typename_inner(parse_stream: DeriveInput) -> TokenStream {
         Ident::new("sunscreen", Span::call_site())
     };
 
-    TokenStream::from(quote! {
+    quote! {
         impl #sunscreen_path ::types::TypeName for #name {
             fn type_name() -> #sunscreen_path ::types::Type {
                 let version = env!("CARGO_PKG_VERSION");
@@ -47,5 +45,5 @@ fn derive_typename_inner(parse_stream: DeriveInput) -> TokenStream {
                 }
             }
         }
-    })
+    }
 }

--- a/sunscreen_fhe_program/src/error.rs
+++ b/sunscreen_fhe_program/src/error.rs
@@ -7,7 +7,7 @@ use crate::{EdgeInfo, OutputType};
  */
 pub type OpName = String;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /**
  * Represents an error that can occur in this crate.
  */
@@ -27,7 +27,7 @@ pub enum Error {
 /**
  * An error in an [`FheProgram`](crate::FheProgram).
  */
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum IRError {
     /**
      * The IR has a cycle.
@@ -43,7 +43,7 @@ pub enum IRError {
 /**
  * An error on a node in an [`FheProgram`](crate::FheProgram).
  */
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NodeError {
     /**
      * The node is missing an expected operand of the contained type.

--- a/sunscreen_fhe_program/src/traversal.rs
+++ b/sunscreen_fhe_program/src/traversal.rs
@@ -19,7 +19,7 @@ pub fn get_left_right_operands(ir: &FheProgram, index: NodeIndex) -> (NodeIndex,
         .edges_directed(index, Direction::Incoming)
         .filter(|e| *e.weight() == EdgeInfo::LeftOperand)
         .map(|e| e.source())
-        .nth(0)
+        .next()
         .unwrap();
 
     let right = ir
@@ -27,7 +27,7 @@ pub fn get_left_right_operands(ir: &FheProgram, index: NodeIndex) -> (NodeIndex,
         .edges_directed(index, Direction::Incoming)
         .filter(|e| *e.weight() == EdgeInfo::RightOperand)
         .map(|e| e.source())
-        .nth(0)
+        .next()
         .unwrap();
 
     (left, right)
@@ -48,6 +48,6 @@ pub fn get_unary_operand(ir: &FheProgram, index: NodeIndex) -> NodeIndex {
         .edges_directed(index, Direction::Incoming)
         .filter(|e| *e.weight() == EdgeInfo::UnaryOperand)
         .map(|e| e.source())
-        .nth(0)
+        .next()
         .unwrap()
 }

--- a/sunscreen_fhe_program/src/validation.rs
+++ b/sunscreen_fhe_program/src/validation.rs
@@ -206,12 +206,9 @@ fn validate_unary_op_has_correct_operands(ir: &FheProgram, index: NodeIndex) -> 
 
     let operand = get_unary_operand(ir, index);
 
-    match operand {
-        None => {
-            errors.push(NodeError::MissingOperand(EdgeInfo::UnaryOperand));
-        }
-        _ => {}
-    };
+    if operand.is_none() {
+        errors.push(NodeError::MissingOperand(EdgeInfo::UnaryOperand));
+    }
 
     errors
 }

--- a/sunscreen_fhe_program/src/validation.rs
+++ b/sunscreen_fhe_program/src/validation.rs
@@ -225,14 +225,14 @@ fn get_left_right_operands(
         .edges_directed(index, Direction::Incoming)
         .filter(|e| *e.weight() == EdgeInfo::LeftOperand)
         .map(|e| e.source())
-        .nth(0);
+        .next();
 
     let right = ir
         .graph
         .edges_directed(index, Direction::Incoming)
         .filter(|e| *e.weight() == EdgeInfo::RightOperand)
         .map(|e| e.source())
-        .nth(0);
+        .next();
 
     (left, right)
 }
@@ -242,7 +242,7 @@ pub fn get_unary_operand(ir: &FheProgram, index: NodeIndex) -> Option<NodeIndex>
         .edges_directed(index, Direction::Incoming)
         .filter(|e| *e.weight() == EdgeInfo::UnaryOperand)
         .map(|e| e.source())
-        .nth(0)
+        .next()
 }
 
 #[cfg(test)]

--- a/sunscreen_runtime/src/error.rs
+++ b/sunscreen_runtime/src/error.rs
@@ -1,6 +1,6 @@
 use crate::Type;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 /**
  * Represents an error that can occur in this crate.
  */

--- a/sunscreen_runtime/src/lib.rs
+++ b/sunscreen_runtime/src/lib.rs
@@ -44,6 +44,13 @@ impl InnerPlaintext {
     }
 
     /**
+     * Returns whether or not there are any plaintexts inside this wrapper.
+     */
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /**
      * Decompose the N plaintexts inside this wrapper into N wrappers
      * with 1 plaintext each. Useful for creating plaintext constants
      * in FHE programs.

--- a/sunscreen_runtime/src/lib.rs
+++ b/sunscreen_runtime/src/lib.rs
@@ -80,7 +80,7 @@ impl InnerPlaintext {
      */
     pub fn as_seal_plaintext(&self) -> Result<&[WithContext<SealPlaintext>]> {
         match self {
-            Self::Seal(d) => Ok(&d),
+            Self::Seal(d) => Ok(d),
         }
     }
 }
@@ -135,7 +135,7 @@ impl Plaintext {
      * error if the inner plaintext is not a Seal plaintext.
      */
     pub fn inner_as_seal_plaintext(&self) -> Result<&[WithContext<SealPlaintext>]> {
-        Ok(self.inner.as_seal_plaintext()?)
+        self.inner.as_seal_plaintext()
     }
 }
 

--- a/sunscreen_runtime/src/metadata.rs
+++ b/sunscreen_runtime/src/metadata.rs
@@ -14,7 +14,7 @@ use std::str::FromStr;
 /**
  * A type which represents the fully qualified name and version of a datatype.
  */
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Type {
     /**
      * The fully qualified name of the type (including crate name)
@@ -56,24 +56,22 @@ impl<'de> Visitor<'de> for TypeNameVisitor {
     where
         E: de::Error,
     {
-        let splits: Vec<&str> = s.split(",").collect();
+        let splits: Vec<&str> = s.split(',').collect();
 
         if splits.len() != 3 {
             Err(de::Error::invalid_value(de::Unexpected::Str(s), &self))
+        } else if let Err(_) = Version::parse(splits[1]) {
+            Err(de::Error::invalid_value(
+                de::Unexpected::Str(splits[1]),
+                &self,
+            ))
+        } else if bool::from_str(splits[2]).is_err() {
+            Err(de::Error::invalid_value(
+                de::Unexpected::Str(splits[2]),
+                &self,
+            ))
         } else {
-            if let Err(_) = Version::parse(splits[1]) {
-                Err(de::Error::invalid_value(
-                    de::Unexpected::Str(splits[1]),
-                    &self,
-                ))
-            } else if let Err(_) = bool::from_str(splits[2]) {
-                Err(de::Error::invalid_value(
-                    de::Unexpected::Str(splits[2]),
-                    &self,
-                ))
-            } else {
-                Ok(s.to_owned())
-            }
+            Ok(s.to_owned())
         }
     }
 }
@@ -85,7 +83,7 @@ impl<'de> Deserialize<'de> for Type {
     {
         let type_string = deserializer.deserialize_string(TypeNameVisitor)?;
 
-        let mut splits = type_string.split(",");
+        let mut splits = type_string.split(',');
 
         let typename = splits.next().ok_or(D::Error::custom(""))?;
         let version = Version::parse(splits.next().ok_or(D::Error::custom(""))?)
@@ -110,7 +108,7 @@ impl<'de> Deserialize<'de> for Type {
  * to consumers without revealing this FHE program's implementation. This allows
  * users to encrypt their data in a verifiable manner.
  */
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CallSignature {
     /**
      * The type of each argument in the FHE program.
@@ -138,7 +136,7 @@ pub struct CallSignature {
     pub num_ciphertexts: Vec<usize>,
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /**
  * A key type required for an Fhe Program to function correctly.
  */
@@ -158,7 +156,7 @@ pub enum RequiredKeys {
     PublicKey,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 /**
  * The parameter set required for a given FHE program to run efficiently and correctly.
  */
@@ -267,7 +265,7 @@ impl Params {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 /**
  * A serializable list of requirements for an Fhe Program.
  */

--- a/sunscreen_runtime/src/metadata.rs
+++ b/sunscreen_runtime/src/metadata.rs
@@ -60,7 +60,7 @@ impl<'de> Visitor<'de> for TypeNameVisitor {
 
         if splits.len() != 3 {
             Err(de::Error::invalid_value(de::Unexpected::Str(s), &self))
-        } else if let Err(_) = Version::parse(splits[1]) {
+        } else if Version::parse(splits[1]).is_err() {
             Err(de::Error::invalid_value(
                 de::Unexpected::Str(splits[1]),
                 &self,
@@ -85,11 +85,11 @@ impl<'de> Deserialize<'de> for Type {
 
         let mut splits = type_string.split(',');
 
-        let typename = splits.next().ok_or(D::Error::custom(""))?;
-        let version = Version::parse(splits.next().ok_or(D::Error::custom(""))?)
+        let typename = splits.next().ok_or_else(|| D::Error::custom(""))?;
+        let version = Version::parse(splits.next().ok_or_else(|| D::Error::custom(""))?)
             .map_err(|e| de::Error::custom(format!("Failed to parse version: {}", e)))?;
 
-        let is_encrypted = bool::from_str(splits.next().ok_or(D::Error::custom(""))?)
+        let is_encrypted = bool::from_str(splits.next().ok_or_else(|| D::Error::custom(""))?)
             .map_err(|e| de::Error::custom(format!("Failed to parse boolean: {}", e)))?;
 
         Ok(Self {

--- a/sunscreen_runtime/src/run.rs
+++ b/sunscreen_runtime/src/run.rs
@@ -15,7 +15,7 @@ use seal_fhe::{
     Ciphertext, Error as SealError, Evaluator, GaloisKeys, Plaintext, RelinearizationKeys,
 };
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 /**
  * An error that occurs while running an Fhe Program.
  */
@@ -216,7 +216,7 @@ pub unsafe fn run_program_unchecked<E: Evaluator + Sync + Send>(
                     let a = get_ciphertext(&data, left.index())?;
                     let b = get_ciphertext(&data, right.index())?;
 
-                    let c = evaluator.add(&a, &b)?;
+                    let c = evaluator.add(a, b)?;
 
                     data[index.index()].store(Some(Arc::new(c.into())));
                 }
@@ -226,7 +226,7 @@ pub unsafe fn run_program_unchecked<E: Evaluator + Sync + Send>(
                     let a = get_ciphertext(&data, left.index())?;
                     let b = get_plaintext(&data, right.index())?;
 
-                    let c = evaluator.add_plain(&a, &b)?;
+                    let c = evaluator.add_plain(a, b)?;
 
                     data[index.index()].store(Some(Arc::new(c.into())));
                 }
@@ -236,7 +236,7 @@ pub unsafe fn run_program_unchecked<E: Evaluator + Sync + Send>(
                     let a = get_ciphertext(&data, left.index())?;
                     let b = get_ciphertext(&data, right.index())?;
 
-                    let c = evaluator.multiply(&a, &b)?;
+                    let c = evaluator.multiply(a, b)?;
 
                     data[index.index()].store(Some(Arc::new(c.into())));
                 }
@@ -246,7 +246,7 @@ pub unsafe fn run_program_unchecked<E: Evaluator + Sync + Send>(
                     let a = get_ciphertext(&data, left.index())?;
                     let b = get_plaintext(&data, right.index())?;
 
-                    let c = evaluator.multiply_plain(&a, &b)?;
+                    let c = evaluator.multiply_plain(a, b)?;
 
                     data[index.index()].store(Some(Arc::new(c.into())));
                 }
@@ -259,7 +259,7 @@ pub unsafe fn run_program_unchecked<E: Evaluator + Sync + Send>(
 
                     let x = get_ciphertext(&data, input.index())?;
 
-                    let y = evaluator.rotate_columns(&x, galois_keys)?;
+                    let y = evaluator.rotate_columns(x, galois_keys)?;
 
                     data[index.index()].store(Some(Arc::new(y.into())));
                 }
@@ -272,7 +272,7 @@ pub unsafe fn run_program_unchecked<E: Evaluator + Sync + Send>(
 
                     let a = get_ciphertext(&data, input.index())?;
 
-                    let c = evaluator.relinearize(&a, relin_keys)?;
+                    let c = evaluator.relinearize(a, relin_keys)?;
 
                     data[index.index()].store(Some(Arc::new(c.into())));
                 }
@@ -281,7 +281,7 @@ pub unsafe fn run_program_unchecked<E: Evaluator + Sync + Send>(
 
                     let x = get_ciphertext(&data, x_id.index())?;
 
-                    let y = evaluator.negate(&x)?;
+                    let y = evaluator.negate(x)?;
 
                     data[index.index()].store(Some(Arc::new(y.into())));
                 }
@@ -291,7 +291,7 @@ pub unsafe fn run_program_unchecked<E: Evaluator + Sync + Send>(
                     let a = get_ciphertext(&data, left.index())?;
                     let b = get_ciphertext(&data, right.index())?;
 
-                    let c = evaluator.sub(&a, &b)?;
+                    let c = evaluator.sub(a, b)?;
 
                     data[index.index()].store(Some(Arc::new(c.into())));
                 }
@@ -301,14 +301,14 @@ pub unsafe fn run_program_unchecked<E: Evaluator + Sync + Send>(
                     let a = get_ciphertext(&data, left.index())?;
                     let b = get_plaintext(&data, right.index())?;
 
-                    let c = evaluator.sub_plain(&a, &b)?;
+                    let c = evaluator.sub_plain(a, b)?;
 
                     data[index.index()].store(Some(Arc::new(c.into())));
                 }
                 Literal(x) => {
                     match x {
                         Literal::Plaintext(p) => {
-                            let p = InnerPlaintext::from_bytes(&p)
+                            let p = InnerPlaintext::from_bytes(p)
                                 .map_err(|_| FheProgramRunFailure::MalformedPlaintext)?;
 
                             match p {
@@ -378,7 +378,7 @@ where
     F: Fn(NodeIndex) -> Result<(), FheProgramRunFailure> + Sync + Send,
 {
     let ir = if let Some(x) = run_to {
-        Cow::Owned(ir.prune(&vec![x])) // MOO
+        Cow::Owned(ir.prune(&[x])) // MOO
     } else {
         Cow::Borrowed(ir) // moo
     };

--- a/sunscreen_runtime/src/serialization.rs
+++ b/sunscreen_runtime/src/serialization.rs
@@ -6,7 +6,7 @@ use serde::{
     Deserialize, Serialize,
 };
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 /**
  * A data type that contains parameters for reconstructing a context
  * during deserialization (needed by SEAL).
@@ -140,17 +140,15 @@ where
                         .map_err(|e| serde::de::Error::custom(format!("{}", e)))?;
 
                     Ok(WithContext::<T> { params, data })
+                } else if params_empty {
+                    Err(serde::de::Error::missing_field("params"))
                 } else {
-                    if params_empty {
-                        Err(serde::de::Error::missing_field("params"))
-                    } else {
-                        Err(serde::de::Error::missing_field("key"))
-                    }
+                    Err(serde::de::Error::missing_field("key"))
                 }
             }
         }
 
-        const FIELDS: &'static [&'static str] = &["params", "key"];
+        const FIELDS: &[&str] = &["params", "key"];
         deserializer.deserialize_struct(
             "WithContext",
             FIELDS,
@@ -179,7 +177,7 @@ where
 
     let seal_context = Context::new(&encryption_params, false, params.security_level)?;
 
-    let data = T::from_bytes(&seal_context, &data)?;
+    let data = T::from_bytes(&seal_context, data)?;
 
     Ok(data)
 }

--- a/sunscreen_runtime/src/serialization.rs
+++ b/sunscreen_runtime/src/serialization.rs
@@ -159,7 +159,7 @@ where
     }
 }
 
-fn deserialize_with_params<'de, T>(params: &Params, data: &[u8]) -> Result<T, seal_fhe::Error>
+fn deserialize_with_params<T>(params: &Params, data: &[u8]) -> Result<T, seal_fhe::Error>
 where
     T: FromBytes,
 {


### PR DESCRIPTION
This PR
- Runs clippy against all targets in CI, failing the build on any warnings
- Fixes the current warnings.

Most of the changes are small and uncontroversial. However there were a few warnings where I felt the default clippy behavior would hinder readability, or simply weren't relevant for us. In those cases I added ad-hoc `#[allow]` pragmas.

Definitely let me know if you'd like fewer or more things to be `allow`ed. In fact, it may make sense to add a `clippy.toml` for certain things across the board. For example, some of the example programs that simulate lines of equations use large input / output tuples, and clippy complains about type complexity, but I think type synonyms would probably only add confusion there :shrug:  Let me know what you think.