### PR TITLE
README: make git submodule command recursive

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ Install [git](https://git-scm.com/download/win). Defaults are fine.
 
 ## Initialize submodules
 ```
-git submodule init
-git submodule update
+git submodule update --init --recursive
 ```
 
 # Dev workflows


### PR DESCRIPTION
Without the `--recursive` flag, I was getting an error from `cargo build`.  And I figured I might as well fold the init into the update while I'm at it.

This is the error I was getting:

```
  --- stderr
  CMake Error at cmake/ExternalZLIB.cmake:31 (add_subdirectory):
    The source directory

      /home/or/oss/Sunscreen/target/debug/build/seal_fhe-36c0980c14f6d68e/out/build/thirdparty/zlib

    does not contain a CMakeLists.txt file.
  Call Stack (most recent call first):
    CMakeLists.txt:167 (include)


  CMake Error at cmake/ExternalZSTD.cmake:20 (add_subdirectory):
    add_subdirectory given source
    "/home/or/oss/Sunscreen/seal_fhe/SEAL/thirdparty/zstd/build/cmake" which is
    not an existing directory.
  Call Stack (most recent call first):
    CMakeLists.txt:187 (include)


  thread 'main' panicked at '
  command did not execute successfully, got: exit status: 1
```