### PR TITLE
Runtime now takes a ZKP backend

### DIFF
--- a/sunscreen/Cargo.toml
+++ b/sunscreen/Cargo.toml
@@ -36,10 +36,12 @@ static_assertions = "1.1.0"
 thiserror = "1.0.37"
 
 [dev-dependencies]
+sunscreen_zkp_backend = { path = "../sunscreen_zkp_backend", features = ["bulletproofs"] }
 sunscreen_compiler_common = { path = "../sunscreen_compiler_common" }
 serde_json = "1.0.74"
 float-cmp = "0.9.0"
 
 [features]
+bulletproofs = ["sunscreen_zkp_backend/bulletproofs"]
 hexl = ["seal_fhe/hexl"]
 

--- a/sunscreen/tests/zkp_program_tests.rs
+++ b/sunscreen/tests/zkp_program_tests.rs
@@ -1,5 +1,5 @@
 use sunscreen::{types::zkp::NativeField, zkp_program, Compiler, Runtime, ZkpProgramFn};
-use sunscreen_zkp_backend::BigInt;
+use sunscreen_zkp_backend::{BigInt, bulletproofs::BulletproofsBackend};
 
 #[test]
 fn can_add_and_mul_native_fields() {
@@ -12,7 +12,7 @@ fn can_add_and_mul_native_fields() {
 
     let app = Compiler::new().zkp_program(add_mul).compile().unwrap();
 
-    let runtime = Runtime::new_zkp().unwrap();
+    let runtime = Runtime::new_zkp(BulletproofsBackend::new()).unwrap();
 
     let program = app.get_zkp_program(add_mul).unwrap();
 
@@ -38,7 +38,7 @@ fn get_input_mismatch_on_incorrect_args() {
 
     let app = Compiler::new().zkp_program(add_mul).compile().unwrap();
 
-    let runtime = Runtime::new_zkp().unwrap();
+    let runtime = Runtime::new_zkp(BulletproofsBackend::new()).unwrap();
 
     let program = app.get_zkp_program(add_mul).unwrap();
 

--- a/sunscreen/tests/zkp_program_tests.rs
+++ b/sunscreen/tests/zkp_program_tests.rs
@@ -1,5 +1,5 @@
 use sunscreen::{types::zkp::NativeField, zkp_program, Compiler, Runtime, ZkpProgramFn};
-use sunscreen_zkp_backend::{BigInt, bulletproofs::BulletproofsBackend};
+use sunscreen_zkp_backend::{bulletproofs::BulletproofsBackend, BigInt};
 
 #[test]
 fn can_add_and_mul_native_fields() {
@@ -12,7 +12,7 @@ fn can_add_and_mul_native_fields() {
 
     let app = Compiler::new().zkp_program(add_mul).compile().unwrap();
 
-    let runtime = Runtime::new_zkp(BulletproofsBackend::new()).unwrap();
+    let runtime = Runtime::new_zkp(&BulletproofsBackend::new()).unwrap();
 
     let program = app.get_zkp_program(add_mul).unwrap();
 
@@ -38,7 +38,7 @@ fn get_input_mismatch_on_incorrect_args() {
 
     let app = Compiler::new().zkp_program(add_mul).compile().unwrap();
 
-    let runtime = Runtime::new_zkp(BulletproofsBackend::new()).unwrap();
+    let runtime = Runtime::new_zkp(&BulletproofsBackend::new()).unwrap();
 
     let program = app.get_zkp_program(add_mul).unwrap();
 

--- a/sunscreen_runtime/src/runtime.rs
+++ b/sunscreen_runtime/src/runtime.rs
@@ -17,13 +17,10 @@ use seal_fhe::{
 };
 
 pub use sunscreen_compiler_common::{Type, TypeName};
-use sunscreen_zkp_backend::bulletproofs::BulletproofsR1CSCircuit;
-use sunscreen_zkp_backend::jit;
 use sunscreen_zkp_backend::BigInt;
 use sunscreen_zkp_backend::CompiledZkpProgram;
 use sunscreen_zkp_backend::Proof;
-use sunscreen_zkp_backend::ZkpProverBackend;
-use sunscreen_zkp_backend::ZkpVerifierBackend;
+use sunscreen_zkp_backend::ZkpBackend;
 
 enum Context {
     Seal(SealContext),
@@ -70,9 +67,14 @@ struct FheRuntimeData {
     context: Context,
 }
 
+struct ZkpRuntimeData {
+    backend: Box<dyn ZkpBackend>,
+}
+
 enum RuntimeData {
     Fhe(FheRuntimeData),
-    Zkp,
+    Zkp(ZkpRuntimeData),
+    FheZkp(FheRuntimeData, ZkpRuntimeData)
 }
 
 impl RuntimeData {
@@ -86,9 +88,19 @@ impl RuntimeData {
     fn unwrap_fhe(&self) -> &FheRuntimeData {
         match self {
             Self::Fhe(x) => x,
-            _ => panic!("Expected RuntimeData::Fhe."),
+            Self::FheZkp(x, _) => x,
+            _ => panic!("Expected RuntimeData::Fhe or RuntimeData::FheZkp."),
         }
     }
+
+    fn unwrap_zkp(&self) -> &ZkpRuntimeData {
+        match self {
+            Self::Zkp(x) => x,
+            Self::FheZkp(_, x) => x,
+            _ => panic!("Expected RuntimeData::Zkp or RuntimeData::FheZkp.")
+        }
+    }
+
 }
 
 /**
@@ -431,18 +443,19 @@ where
      * Prove the given `inputs` satisfy `program`.
      */
     pub fn prove(&self, program: &CompiledZkpProgram, inputs: &[BigInt]) -> Result<Proof> {
-        let prog = jit(program);
-
-        Ok(BulletproofsR1CSCircuit::prove(&prog, inputs)?)
+        let backend = &self.runtime_data.unwrap_zkp().backend;
+        let prog = backend.jit(program)?;
+        Ok(backend.prove(&prog, inputs)?)
     }
 
     /**
      * Verify that the given `proof` satisfies the given `program`.
      */
     pub fn verify(&self, program: &CompiledZkpProgram, proof: &Proof) -> Result<()> {
-        let prog = jit(program);
+        let backend = &self.runtime_data.unwrap_zkp().backend;
+        let prog = backend.jit(program)?;
 
-        Ok(BulletproofsR1CSCircuit::verify(&prog, proof)?)
+        Ok(backend.verify(&prog, proof)?)
     }
 }
 
@@ -458,10 +471,7 @@ impl GenericRuntime<()> {
         Self::new_fhe(params)
     }
 
-    /**
-     * Create a new Runtime supporting only FHE operations.
-     */
-    pub fn new_fhe(params: &Params) -> Result<FheRuntime> {
+    fn make_fhe_runtime_data(params: &Params) -> Result<FheRuntimeData> {
         match params.scheme_type {
             SchemeType::Bfv => {
                 let bfv_params = BfvEncryptionParametersBuilder::new()
@@ -478,23 +488,32 @@ impl GenericRuntime<()> {
 
                 let context = SealContext::new(&bfv_params, true, params.security_level)?;
 
-                Ok(GenericRuntime {
-                    runtime_data: RuntimeData::Fhe(FheRuntimeData {
-                        context: Context::Seal(context),
-                        params: params.clone(),
-                    }),
-                    _phantom: PhantomData,
-                })
+                Ok(FheRuntimeData { params: params.clone(), context: Context::Seal(context)})
             }
         }
+    }
+
+    fn make_zkp_runtime_data<B>(backend: B) -> ZkpRuntimeData where B: ZkpBackend + Clone + 'static {
+        ZkpRuntimeData { backend: Box::new(backend.clone()) }
+   
+    }
+
+    /**
+     * Create a new Runtime supporting only FHE operations.
+     */
+    pub fn new_fhe(params: &Params) -> Result<FheRuntime> {
+        Ok(GenericRuntime {
+            runtime_data: RuntimeData::Fhe(Self::make_fhe_runtime_data(params)?),
+            _phantom: PhantomData,
+        })
     }
 
     /**
      * Creates a new Runtime supporting only ZKP operations
      */
-    pub fn new_zkp() -> Result<ZkpRuntime> {
+    pub fn new_zkp<B>(backend: B) -> Result<ZkpRuntime> where B: ZkpBackend + Clone + 'static {
         Ok(GenericRuntime {
-            runtime_data: RuntimeData::Zkp,
+            runtime_data: RuntimeData::Zkp(Self::make_zkp_runtime_data( backend)),
             _phantom: PhantomData,
         })
     }
@@ -502,11 +521,14 @@ impl GenericRuntime<()> {
     /**
      * Creates a new Runtime supporting both ZKP and FHE operations.
      */
-    pub fn new_fhe_zkp(params: &Params) -> Result<FheZkpRuntime> {
-        let runtime = Self::new_fhe(params)?;
+    pub fn new_fhe_zkp<B>(params: &Params, zkp_backend: B) -> Result<FheZkpRuntime> where B: ZkpBackend + Clone + 'static {
+        let runtime_data = RuntimeData::FheZkp(
+            Self::make_fhe_runtime_data(params)?,
+            Self::make_zkp_runtime_data(zkp_backend)
+        );
 
         Ok(GenericRuntime {
-            runtime_data: runtime.runtime_data,
+            runtime_data,
             _phantom: PhantomData,
         })
     }

--- a/sunscreen_runtime/src/runtime.rs
+++ b/sunscreen_runtime/src/runtime.rs
@@ -74,7 +74,7 @@ struct ZkpRuntimeData {
 enum RuntimeData {
     Fhe(FheRuntimeData),
     Zkp(ZkpRuntimeData),
-    FheZkp(FheRuntimeData, ZkpRuntimeData)
+    FheZkp(FheRuntimeData, ZkpRuntimeData),
 }
 
 impl RuntimeData {
@@ -97,10 +97,9 @@ impl RuntimeData {
         match self {
             Self::Zkp(x) => x,
             Self::FheZkp(_, x) => x,
-            _ => panic!("Expected RuntimeData::Zkp or RuntimeData::FheZkp.")
+            _ => panic!("Expected RuntimeData::Zkp or RuntimeData::FheZkp."),
         }
     }
-
 }
 
 /**
@@ -488,14 +487,21 @@ impl GenericRuntime<()> {
 
                 let context = SealContext::new(&bfv_params, true, params.security_level)?;
 
-                Ok(FheRuntimeData { params: params.clone(), context: Context::Seal(context)})
+                Ok(FheRuntimeData {
+                    params: params.clone(),
+                    context: Context::Seal(context),
+                })
             }
         }
     }
 
-    fn make_zkp_runtime_data<B>(backend: B) -> ZkpRuntimeData where B: ZkpBackend + Clone + 'static {
-        ZkpRuntimeData { backend: Box::new(backend.clone()) }
-   
+    fn make_zkp_runtime_data<B>(backend: &B) -> ZkpRuntimeData
+    where
+        B: ZkpBackend + Clone + 'static,
+    {
+        ZkpRuntimeData {
+            backend: Box::new(backend.clone()),
+        }
     }
 
     /**
@@ -511,9 +517,12 @@ impl GenericRuntime<()> {
     /**
      * Creates a new Runtime supporting only ZKP operations
      */
-    pub fn new_zkp<B>(backend: B) -> Result<ZkpRuntime> where B: ZkpBackend + Clone + 'static {
+    pub fn new_zkp<B>(backend: &B) -> Result<ZkpRuntime>
+    where
+        B: ZkpBackend + Clone + 'static,
+    {
         Ok(GenericRuntime {
-            runtime_data: RuntimeData::Zkp(Self::make_zkp_runtime_data( backend)),
+            runtime_data: RuntimeData::Zkp(Self::make_zkp_runtime_data(backend)),
             _phantom: PhantomData,
         })
     }
@@ -521,10 +530,13 @@ impl GenericRuntime<()> {
     /**
      * Creates a new Runtime supporting both ZKP and FHE operations.
      */
-    pub fn new_fhe_zkp<B>(params: &Params, zkp_backend: B) -> Result<FheZkpRuntime> where B: ZkpBackend + Clone + 'static {
+    pub fn new_fhe_zkp<B>(params: &Params, zkp_backend: &B) -> Result<FheZkpRuntime>
+    where
+        B: ZkpBackend + Clone + 'static,
+    {
         let runtime_data = RuntimeData::FheZkp(
             Self::make_fhe_runtime_data(params)?,
-            Self::make_zkp_runtime_data(zkp_backend)
+            Self::make_zkp_runtime_data(zkp_backend),
         );
 
         Ok(GenericRuntime {

--- a/sunscreen_zkp_backend/src/bulletproofs.rs
+++ b/sunscreen_zkp_backend/src/bulletproofs.rs
@@ -457,7 +457,7 @@ mod tests {
 
         assert!(Scalar::try_from(&l).is_err());
 
-        let l_min_1 = l.clone().0.wrapping_sub(&U512::ONE);
+        let l_min_1 = l.0.wrapping_sub(&U512::ONE);
         let scalar = try_uint_to_scalar(&l_min_1).unwrap();
 
         assert_eq!(BigInt::from(l_min_1), scalar_to_u512(&scalar));

--- a/sunscreen_zkp_backend/src/bulletproofs.rs
+++ b/sunscreen_zkp_backend/src/bulletproofs.rs
@@ -1,8 +1,8 @@
-use std::ops::{Add, Mul, Neg, Sub, Deref};
+use std::ops::{Add, Deref, Mul, Neg, Sub};
 
 use bulletproofs::{
     r1cs::{ConstraintSystem, LinearCombination, Prover, R1CSError, R1CSProof, Verifier},
-    BulletproofGens, PedersenGens
+    BulletproofGens, PedersenGens,
 };
 use crypto_bigint::{Limb, UInt};
 use curve25519_dalek::scalar::Scalar;
@@ -12,7 +12,8 @@ use serde::{Deserialize, Serialize};
 use sunscreen_compiler_common::forward_traverse;
 
 use crate::{
-    exec::Operation, BigInt, Error, ExecutableZkpProgram, Proof, Result, ZkpBackend, jit, BackendField,
+    exec::Operation, jit, BackendField, BigInt, Error, ExecutableZkpProgram, Proof, Result,
+    ZkpBackend,
 };
 
 #[derive(Clone)]
@@ -294,8 +295,7 @@ impl ZkpBackend for BulletproofsBackend {
             .collect::<Result<Vec<Scalar>>>()?;
 
         let transcript = BulletproofsCircuit::make_transcript(multiplier_count);
-        let (pedersen_gens, bulletproof_gens) =
-            BulletproofsCircuit::make_gens(multiplier_count);
+        let (pedersen_gens, bulletproof_gens) = BulletproofsCircuit::make_gens(multiplier_count);
 
         let mut circuit = BulletproofsCircuit::new(graph.node_count());
 
@@ -322,8 +322,7 @@ impl ZkpBackend for BulletproofsBackend {
             .count();
 
         let transcript = BulletproofsCircuit::make_transcript(multiplier_count);
-        let (pedersen_gens, bulletproof_gens) =
-            BulletproofsCircuit::make_gens(multiplier_count);
+        let (pedersen_gens, bulletproof_gens) = BulletproofsCircuit::make_gens(multiplier_count);
 
         let mut circuit = BulletproofsCircuit::new(graph.node_count());
 
@@ -332,7 +331,6 @@ impl ZkpBackend for BulletproofsBackend {
         circuit.gen_circuit(graph, &mut verifier, |_| None)?;
 
         Ok(verifier.verify(&proof.0, &pedersen_gens, &bulletproof_gens)?)
-
     }
 
     fn jit(&self, prog: &crate::CompiledZkpProgram) -> Result<ExecutableZkpProgram> {
@@ -370,8 +368,7 @@ fn try_uint_to_scalar<const N: usize>(x: &UInt<N>) -> Result<Scalar> {
 
 impl BackendField for Scalar {}
 
-impl TryFrom<BigInt> for Scalar
-{
+impl TryFrom<BigInt> for Scalar {
     type Error = Error;
 
     fn try_from(value: BigInt) -> Result<Self> {
@@ -379,8 +376,7 @@ impl TryFrom<BigInt> for Scalar
     }
 }
 
-impl TryFrom<&BigInt> for Scalar
-{
+impl TryFrom<&BigInt> for Scalar {
     type Error = Error;
 
     fn try_from(value: &BigInt) -> Result<Self> {
@@ -502,42 +498,45 @@ mod tests {
         let backend = BulletproofsBackend::new();
 
         // 10 * 4 + 2 == 42
-        let proof = backend.prove(
-            &graph,
-            &[
-                BigInt::from_u32(10),
-                BigInt::from_u32(4),
-                BigInt::from_u32(2),
-            ],
-        )
-        .unwrap();
+        let proof = backend
+            .prove(
+                &graph,
+                &[
+                    BigInt::from_u32(10),
+                    BigInt::from_u32(4),
+                    BigInt::from_u32(2),
+                ],
+            )
+            .unwrap();
 
         backend.verify(&graph, &proof).unwrap();
 
         // 8 * 5 + 2 == 42
-        let proof = backend.prove(
-            &graph,
-            &[
-                BigInt::from_u32(8),
-                BigInt::from_u32(5),
-                BigInt::from_u32(2),
-            ],
-        )
-        .unwrap();
+        let proof = backend
+            .prove(
+                &graph,
+                &[
+                    BigInt::from_u32(8),
+                    BigInt::from_u32(5),
+                    BigInt::from_u32(2),
+                ],
+            )
+            .unwrap();
 
         backend.verify(&graph, &proof).unwrap();
 
         // 8 * 5 + 3 == 42.
         // Verification should fail.
-        let proof = backend.prove(
-            &graph,
-            &[
-                BigInt::from(U512::from_u32(8)),
-                BigInt::from(U512::from_u32(5)),
-                BigInt::from(U512::from_u32(3)),
-            ],
-        )
-        .unwrap();
+        let proof = backend
+            .prove(
+                &graph,
+                &[
+                    BigInt::from(U512::from_u32(8)),
+                    BigInt::from(U512::from_u32(5)),
+                    BigInt::from(U512::from_u32(3)),
+                ],
+            )
+            .unwrap();
 
         assert!(backend.verify(&graph, &proof).is_err());
     }

--- a/sunscreen_zkp_backend/src/jit.rs
+++ b/sunscreen_zkp_backend/src/jit.rs
@@ -1,7 +1,6 @@
 use crate::{
     exec::{ExecutableZkpProgram, Operation as ExecOperation},
-    BigInt, BackendField,
-    Result,
+    BackendField, BigInt, Result,
 };
 use sunscreen_compiler_common::{CompilationResult, NodeInfo, Operation as OperationTrait};
 
@@ -51,7 +50,8 @@ pub type CompiledZkpProgram = CompilationResult<Operation>;
  * Just in time compile a [`CompiledZkpProgram`] into an [`ExecutableZkpProgram`]
  */
 pub fn jit<U>(prog: &CompiledZkpProgram) -> Result<ExecutableZkpProgram>
-where U: BackendField
+where
+    U: BackendField,
 {
     let prog = prog.0.map(
         |_, n| {

--- a/sunscreen_zkp_backend/src/jit.rs
+++ b/sunscreen_zkp_backend/src/jit.rs
@@ -1,6 +1,7 @@
 use crate::{
     exec::{ExecutableZkpProgram, Operation as ExecOperation},
-    BigInt,
+    BigInt, BackendField,
+    Result,
 };
 use sunscreen_compiler_common::{CompilationResult, NodeInfo, Operation as OperationTrait};
 
@@ -49,7 +50,9 @@ pub type CompiledZkpProgram = CompilationResult<Operation>;
 /**
  * Just in time compile a [`CompiledZkpProgram`] into an [`ExecutableZkpProgram`]
  */
-pub fn jit(prog: &CompiledZkpProgram) -> ExecutableZkpProgram {
+pub fn jit<U>(prog: &CompiledZkpProgram) -> Result<ExecutableZkpProgram>
+where U: BackendField
+{
     let prog = prog.0.map(
         |_, n| {
             let operation = match n.operation {
@@ -68,5 +71,5 @@ pub fn jit(prog: &CompiledZkpProgram) -> ExecutableZkpProgram {
         |_, e| *e,
     );
 
-    CompilationResult(prog)
+    Ok(CompilationResult(prog))
 }

--- a/sunscreen_zkp_backend/src/lib.rs
+++ b/sunscreen_zkp_backend/src/lib.rs
@@ -5,10 +5,10 @@ mod error;
 mod exec;
 mod jit;
 
-use std::ops::{Add, Sub, Mul, Deref};
+use std::ops::{Add, Deref, Mul, Sub};
 
 pub use crypto_bigint::UInt;
-use crypto_bigint::{U512};
+use crypto_bigint::U512;
 pub use error::*;
 pub use exec::ExecutableZkpProgram;
 pub use jit::{jit, CompiledZkpProgram, Operation};
@@ -44,7 +44,10 @@ pub trait FieldValue {}
 #[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
 pub struct BigInt(U512);
 
-impl<T> From<T> for BigInt where T: Into<U512> {
+impl<T> From<T> for BigInt
+where
+    T: Into<U512>,
+{
     fn from(x: T) -> Self {
         Self(x.into())
     }
@@ -62,7 +65,7 @@ impl BigInt {
     pub const fn from_words(val: [u64; 8]) -> Self {
         Self(U512::from_words(val))
     }
-    
+
     pub const fn from_u32(val: u32) -> Self {
         Self(U512::from_u32(val))
     }

--- a/sunscreen_zkp_backend/src/lib.rs
+++ b/sunscreen_zkp_backend/src/lib.rs
@@ -5,8 +5,10 @@ mod error;
 mod exec;
 mod jit;
 
+use std::ops::{Add, Sub, Mul, Deref};
+
 pub use crypto_bigint::UInt;
-use crypto_bigint::U512;
+use crypto_bigint::{U512};
 pub use error::*;
 pub use exec::ExecutableZkpProgram;
 pub use jit::{jit, CompiledZkpProgram, Operation};
@@ -39,12 +41,45 @@ pub enum Proof {
 
 pub trait FieldValue {}
 
-pub type BigInt = U512;
+#[derive(Debug, Clone, Copy, Hash, Eq, PartialEq)]
+pub struct BigInt(U512);
 
-pub trait ZkpProverBackend {
-    fn prove(graph: &ExecutableZkpProgram, inputs: &[BigInt]) -> Result<Proof>;
+impl<T> From<T> for BigInt where T: Into<U512> {
+    fn from(x: T) -> Self {
+        Self(x.into())
+    }
 }
 
-pub trait ZkpVerifierBackend {
-    fn verify(graph: &ExecutableZkpProgram, proof: &Proof) -> Result<()>;
+impl Deref for BigInt {
+    type Target = U512;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
+
+impl BigInt {
+    pub const fn from_words(val: [u64; 8]) -> Self {
+        Self(U512::from_words(val))
+    }
+    
+    pub const fn from_u32(val: u32) -> Self {
+        Self(U512::from_u32(val))
+    }
+
+    pub fn from_be_hex(hex_str: &str) -> Self {
+        Self(U512::from_be_hex(hex_str))
+    }
+
+    pub const ZERO: Self = Self(U512::ZERO);
+}
+
+pub trait ZkpBackend {
+    fn prove(&self, graph: &ExecutableZkpProgram, inputs: &[BigInt]) -> Result<Proof>;
+
+    fn verify(&self, graph: &ExecutableZkpProgram, proof: &Proof) -> Result<()>;
+
+    fn jit(&self, prog: &CompiledZkpProgram) -> Result<ExecutableZkpProgram>;
+}
+
+pub trait BackendField: Add + Sub + Mul + Clone + TryFrom<BigInt> {}


### PR DESCRIPTION
By taking a ZKP backend, JITing can now evaluate the circuit in the backend's native field type (e.g. Bulletproof Scalars, Groth16 ark_ff::Fp<whatever>). This maximizes extensibility and our ability to support new backends in the future.