### PR TITLE
Improve assert binary gadget

### DIFF
--- a/benchmarks/cannonical_norm_noise_model/src/ops.rs
+++ b/benchmarks/cannonical_norm_noise_model/src/ops.rs
@@ -132,7 +132,7 @@ pub fn encryption_noise(
     for _ in 0..SAMPLES {
         let plaintext = Plaintext::new().unwrap();
         let ciphertext = encryptor.encrypt(&plaintext).unwrap();
-        measured_noise.push(decryptor.invariant_noise(&ciphertext).unwrap() as f64);
+        measured_noise.push(decryptor.invariant_noise(&ciphertext).unwrap());
     }
 
     let measured = stats(&measured_noise);
@@ -236,7 +236,7 @@ pub fn add_noise(
 
         let c = evaluator.add(&a, &b).unwrap();
 
-        measured_noise.push(decryptor.invariant_noise(&c).unwrap() as f64);
+        measured_noise.push(decryptor.invariant_noise(&c).unwrap());
     }
 
     let measured = stats(&measured_noise);
@@ -297,7 +297,7 @@ pub fn add_pt_noise(
         let c = evaluator.add_plain(&a, &b).unwrap();
 
         predicted_noise.push(model.add_ct_pt(decryptor.invariant_noise(&a).unwrap()));
-        measured_noise.push(decryptor.invariant_noise(&c).unwrap() as f64);
+        measured_noise.push(decryptor.invariant_noise(&c).unwrap());
     }
 
     let measured = stats(&measured_noise);
@@ -364,7 +364,7 @@ pub fn mul_noise(
             decryptor.invariant_noise(&b).unwrap(),
         ));
 
-        measured_noise.push(decryptor.invariant_noise(&c).unwrap() as f64);
+        measured_noise.push(decryptor.invariant_noise(&c).unwrap());
     }
 
     let measured = stats(&measured_noise);
@@ -425,7 +425,7 @@ pub fn mul_pt_noise(
         let c = evaluator.multiply_plain(&a, &b).unwrap();
 
         predicted_noise.push(model.mul_ct_pt(decryptor.invariant_noise(&a).unwrap()));
-        measured_noise.push(decryptor.invariant_noise(&c).unwrap() as f64);
+        measured_noise.push(decryptor.invariant_noise(&c).unwrap());
     }
 
     let measured = stats(&measured_noise);

--- a/sunscreen/src/lib.rs
+++ b/sunscreen/src/lib.rs
@@ -85,7 +85,7 @@ pub use sunscreen_runtime::{
     InnerPlaintext, Params, Plaintext, PrivateKey, PublicKey, RequiredKeys, Runtime, WithContext,
     ZkpRuntime,
 };
-pub use sunscreen_zkp_backend::{BackendField, ZkpBackend};
+pub use sunscreen_zkp_backend::{BackendField, Error as ZkpError, Result as ZkpResult, ZkpBackend};
 pub use zkp::ZkpProgramFn;
 pub use zkp::{
     invoke_gadget, with_zkp_ctx, ZkpContext, ZkpData, ZkpFrontendCompilation, CURRENT_ZKP_CTX,

--- a/sunscreen/src/types/bfv/fractional.rs
+++ b/sunscreen/src/types/bfv/fractional.rs
@@ -503,7 +503,7 @@ impl<const INT_BITS: usize> TryIntoPlaintext for Fractional<INT_BITS> {
                 0
             };
 
-            seal_plaintext.set_coefficient(coeff_index as usize, coeff);
+            seal_plaintext.set_coefficient(coeff_index, coeff);
         }
 
         Ok(Plaintext {

--- a/sunscreen/src/types/bfv/signed.rs
+++ b/sunscreen/src/types/bfv/signed.rs
@@ -79,7 +79,7 @@ impl TryIntoPlaintext for Signed {
             let bit_value = (signed_val & 0x1 << i) >> i;
 
             let coeff_value = if self.val < 0 {
-                bit_value * (params.plain_modulus as u64 - bit_value)
+                bit_value * (params.plain_modulus - bit_value)
             } else {
                 bit_value
             };

--- a/sunscreen_compiler_macros/src/internals/attr.rs
+++ b/sunscreen_compiler_macros/src/internals/attr.rs
@@ -200,7 +200,7 @@ impl Parse for FheProgramAttrs {
 
         for i in attrs.keys() {
             if !VALUE_KEYS.iter().any(|x| x == i) {
-                return Err(SynError::new(input.span(), &format!("Unknown key '{}'", i)));
+                return Err(SynError::new(input.span(), format!("Unknown key '{}'", i)));
             }
         }
 
@@ -254,7 +254,7 @@ impl Parse for ZkpProgramAttrs {
 
         for i in attrs.keys() {
             if !VALUE_KEYS.iter().any(|x| x == i) {
-                return Err(SynError::new(input.span(), &format!("Unknown key '{}'", i)));
+                return Err(SynError::new(input.span(), format!("Unknown key '{}'", i)));
             }
         }
 

--- a/sunscreen_zkp_backend/src/jit.rs
+++ b/sunscreen_zkp_backend/src/jit.rs
@@ -347,7 +347,7 @@ where
                     .map(|x| node_outputs[x].clone().into())
                     .collect::<Vec<BigInt>>();
 
-                let hidden_inputs = g.compute_inputs(&args);
+                let hidden_inputs = g.compute_inputs(&args)?;
 
                 let mut next_nodes = query
                     .edges_directed(id, Direction::Outgoing)

--- a/sunscreen_zkp_backend/src/lib.rs
+++ b/sunscreen_zkp_backend/src/lib.rs
@@ -16,7 +16,7 @@ mod jit;
 
 use std::{
     any::Any,
-    ops::{Add, Deref, Mul, Neg, Sub}, panic::RefUnwindSafe,
+    ops::{Add, Deref, Mul, Neg, Sub},
 };
 
 pub use crypto_bigint::UInt;
@@ -72,7 +72,7 @@ compile_error!("This crate currently requires a little endian target architectur
  *
  * and outputs (b_0..b_7)
  */
-pub trait Gadget: Any + RefUnwindSafe {
+pub trait Gadget: Any {
     /**
      * Create the subcircuit for this gadget.
      * * `gadget_inputs` are the node indices of the gadget inputs.
@@ -100,7 +100,7 @@ pub trait Gadget: Any + RefUnwindSafe {
      * * # Remarks
      * The number of returned hidden input values must equal
      * [`hidden_input_count`](Gadget::hidden_input_count).
-     * 
+     *
      * Implementors should ensure this function runs in constant time.
      */
     fn compute_inputs(&self, gadget_inputs: &[BigInt]) -> Result<Vec<BigInt>>;

--- a/sunscreen_zkp_backend/src/lib.rs
+++ b/sunscreen_zkp_backend/src/lib.rs
@@ -16,7 +16,7 @@ mod jit;
 
 use std::{
     any::Any,
-    ops::{Add, Deref, Mul, Neg, Sub},
+    ops::{Add, Deref, Mul, Neg, Sub}, panic::RefUnwindSafe,
 };
 
 pub use crypto_bigint::UInt;
@@ -72,7 +72,7 @@ compile_error!("This crate currently requires a little endian target architectur
  *
  * and outputs (b_0..b_7)
  */
-pub trait Gadget: Any {
+pub trait Gadget: Any + RefUnwindSafe {
     /**
      * Create the subcircuit for this gadget.
      * * `gadget_inputs` are the node indices of the gadget inputs.
@@ -100,8 +100,10 @@ pub trait Gadget: Any {
      * * # Remarks
      * The number of returned hidden input values must equal
      * [`hidden_input_count`](Gadget::hidden_input_count).
+     * 
+     * Implementors should ensure this function runs in constant time.
      */
-    fn compute_inputs(&self, gadget_inputs: &[BigInt]) -> Vec<BigInt>;
+    fn compute_inputs(&self, gadget_inputs: &[BigInt]) -> Result<Vec<BigInt>>;
 
     /**
      * Returns the expected number of gadget inputs.


### PR DESCRIPTION
Reduce cost of asserting a value is binary, move away from panicking in `Gadget::compute_inputs`.