### PR TITLE
Rweber/perf

### DIFF
--- a/logproof/benches/linear_relation.rs
+++ b/logproof/benches/linear_relation.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use ark_ff::{FftField, Field};
 use ark_poly::univariate::DensePolynomial;
-use criterion::{criterion_group, criterion_main, Criterion, black_box};
+use criterion::{criterion_group, criterion_main, Criterion};
 use logproof::{
     crypto::CryptoHash,
     fields::{FpRistretto, FqSeal128_1024, FqSeal128_2048, FqSeal128_4096},
@@ -107,9 +107,9 @@ where
 
     let now = Instant::now();
 
-        proof
-            .verify(&mut transcript, &pk.vk, &gens.g, &gens.h, &u)
-            .unwrap();
+    proof
+        .verify(&mut transcript, &pk.vk, &gens.g, &gens.h, &u)
+        .unwrap();
 
     println!("Verifier time {}s", now.elapsed().as_secs_f64());
 }
@@ -162,14 +162,14 @@ fn params_4096_1ct(_: &mut Criterion) {
 criterion_group!(
     benches,
     params_1024_1ct,
-    /*params_1024_2ct,
+    params_1024_2ct,
     params_1024_3ct,
     params_2048_1ct,
     params_2048_2ct,
     params_2048_3ct,
     params_4096_1ct,
     params_4096_2ct,
-    params_4096_3ct*/
+    params_4096_3ct
 );
 
 criterion_main!(benches);

--- a/logproof/benches/linear_relation.rs
+++ b/logproof/benches/linear_relation.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use ark_ff::{FftField, Field};
 use ark_poly::univariate::DensePolynomial;
-use criterion::{criterion_group, criterion_main, Criterion};
+use criterion::{criterion_group, criterion_main, Criterion, black_box};
 use logproof::{
     crypto::CryptoHash,
     fields::{FpRistretto, FqSeal128_1024, FqSeal128_2048, FqSeal128_4096},
@@ -107,9 +107,9 @@ where
 
     let now = Instant::now();
 
-    proof
-        .verify(&mut transcript, &pk.vk, &gens.g, &gens.h, &u)
-        .unwrap();
+        proof
+            .verify(&mut transcript, &pk.vk, &gens.g, &gens.h, &u)
+            .unwrap();
 
     println!("Verifier time {}s", now.elapsed().as_secs_f64());
 }
@@ -161,14 +161,14 @@ fn params_4096_1ct(_: &mut Criterion) {
 
 criterion_group!(
     benches,
-    params_1024_1ct,
+    /*params_1024_1ct,
     params_1024_2ct,
     params_1024_3ct,
     params_2048_1ct,
     params_2048_2ct,
     params_2048_3ct,
     params_4096_1ct,
-    params_4096_2ct,
+    params_4096_2ct,*/
     params_4096_3ct
 );
 

--- a/logproof/benches/linear_relation.rs
+++ b/logproof/benches/linear_relation.rs
@@ -161,15 +161,15 @@ fn params_4096_1ct(_: &mut Criterion) {
 
 criterion_group!(
     benches,
-    /*params_1024_1ct,
-    params_1024_2ct,
+    params_1024_1ct,
+    /*params_1024_2ct,
     params_1024_3ct,
     params_2048_1ct,
     params_2048_2ct,
     params_2048_3ct,
     params_4096_1ct,
-    params_4096_2ct,*/
-    params_4096_3ct
+    params_4096_2ct,
+    params_4096_3ct*/
 );
 
 criterion_main!(benches);

--- a/logproof/src/inner_product.rs
+++ b/logproof/src/inner_product.rs
@@ -606,9 +606,6 @@ mod tests {
 
     #[cfg(test)]
     mod test {
-        use curve25519_dalek::traits::MultiscalarMul;
-        use rand::thread_rng;
-
         use super::*;
 
         fn validate_proof(n: usize) {

--- a/logproof/src/inner_product.rs
+++ b/logproof/src/inner_product.rs
@@ -400,7 +400,7 @@ impl InnerProductProof {
         // folding our generators g and h and instead computing factors s from each of the
         // challenge scalars.
         //
-        // This allows us to compute a single MSM at the end to compute g and h rather that
+        // This allows us to compute a single MSM at the end to compute g and h rather than
         // performing SM folding.
         for (t_1, t_minus1) in self.t_1.iter().zip(self.t_minus1.iter()) {
             transcript.append_point(b"t-1", t_minus1);
@@ -700,77 +700,6 @@ mod tests {
         #[test]
         fn can_verify_valid_proof_11() {
             validate_proof(11);
-        }
-
-        #[test]
-        fn can_msm_generator_folding() {
-            let gens = LogProofGenerators::new(8);
-
-            let c = (0..3)
-                .map(|_| Scalar::random(&mut thread_rng()))
-                .collect::<Vec<_>>();
-
-            let get_expected_gens = || -> (RistrettoPoint, RistrettoPoint) {
-                let mut g = gens.g.clone();
-                let mut h = gens.h.clone();
-                let mut i = 0;
-
-                loop {
-                    let n_2 = g.len() / 2;
-
-                    if n_2 == 0 {
-                        assert_eq!(g.len(), 1);
-                        return (g[0], h[0]);
-                    }
-
-                    let (g_l, g_r) = g.split_at(n_2);
-                    let (h_l, h_r) = h.split_at(n_2);
-
-                    let g_l = RistrettoPointVec::new(g_l);
-                    let g_r = RistrettoPointVec::new(g_r);
-                    let h_l = RistrettoPointVec::new(h_l);
-                    let h_r = RistrettoPointVec::new(h_r);
-
-                    let c = c[i];
-                    let c_inv = c.invert();
-
-                    g = (g_l + g_r * c).into_iter().collect::<Vec<_>>();
-                    h = (h_l + h_r * c_inv).into_iter().collect::<Vec<_>>();
-                    i += 1;
-                }
-            };
-
-            let s_i = |i| {
-                c.iter().rev().enumerate().fold(Scalar::one(), |p, (j, x)| {
-                    if i & (0x1 << j) != 0 {
-                        p * x
-                    } else {
-                        p
-                    }
-                })
-            };
-
-            let n = gens.g.len();
-
-            let (g_expect, h_expect) = get_expected_gens();
-
-            let s = (0..n).map(s_i).collect::<Vec<_>>();
-
-            assert_eq!(s[0], Scalar::one());
-            assert_eq!(s[1], c[2]);
-            assert_eq!(s[2], c[1]);
-            assert_eq!(s[3], c[2] * c[1]);
-            assert_eq!(s[4], c[0]);
-            assert_eq!(s[5], c[2] * c[0]);
-            assert_eq!(s[6], c[1] * c[0]);
-            assert_eq!(s[7], c[2] * c[1] * c[0]);
-
-            let s_inv = s.iter().map(|s| s.invert()).collect::<Vec<_>>();
-            let g_actual = RistrettoPoint::multiscalar_mul(s.iter(), gens.g.iter());
-            let h_actual = RistrettoPoint::multiscalar_mul(s_inv.iter(), gens.h.iter());
-
-            assert_eq!(g_expect, g_actual);
-            assert_eq!(h_expect, h_actual);
         }
     }
 }

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -1,3 +1,5 @@
+use std::time::Instant;
+
 use ark_ff::{BigInt, BigInteger, FftField, Field, Fp, FpConfig, MontBackend, MontConfig};
 use ark_poly::{univariate::DensePolynomial, Polynomial};
 use bitvec::{slice::BitSlice, vec::BitVec};
@@ -471,15 +473,33 @@ impl LogProof {
 
         transcript.append_point(b"w", &self.w.compress());
 
+        let now = Instant::now();
+        
         let (alpha, beta, gamma, phi, psi) = Self::create_challenges(vk, transcript);
+
+        println!("Create challenges {}s", now.elapsed().as_secs_f64());
+
+        let now = Instant::now();
 
         let g_prime = Self::compute_g_prime(g, &phi);
 
+        println!("g_prime {}s", now.elapsed().as_secs_f64());
+
+        let now = Instant::now();
+
         let v = Self::compute_v(vk, alpha, &beta, &gamma);
 
+        println!("v {}s", now.elapsed().as_secs_f64());
+        let now = Instant::now();
+
         let t = Self::compute_t(&self.w, &g_prime, h, &phi, &psi, &v);
+        println!("t {}s", now.elapsed().as_secs_f64());
+
+        let now = Instant::now();
 
         let x = Self::compute_x(vk, &gamma, &alpha, &beta, &phi, &psi, &v);
+
+        println!("x {}s", now.elapsed().as_secs_f64());
 
         let ip_vk = inner_product::VerifierKnowledge { t, x };
 

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -474,7 +474,7 @@ impl LogProof {
         transcript.append_point(b"w", &self.w.compress());
 
         let now = Instant::now();
-        
+
         let (alpha, beta, gamma, phi, psi) = Self::create_challenges(vk, transcript);
 
         println!("Create challenges {}s", now.elapsed().as_secs_f64());


### PR DESCRIPTION
Instead of recursively compacting the generator vectors using scalar multiplications, we precompute what the factors should be and perform a single MSM. See Bulletproofs section 3.1 for a more formal writeup of this optimization.