### PR TITLE
Add a `bfv::Unsigned` type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2099,6 +2099,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74605f360ce573babfe43964cbe520294dcb081afbf8c108fc6e23036b4da2df"
 
 [[package]]
+name = "proptest"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29f1b898011ce9595050a68e60f90bad083ff2987a695a42357134c8381fba70"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits 0.2.15",
+ "quick-error 2.0.1",
+ "rand",
+ "rand_chacha",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2161,6 +2194,15 @@ checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits 0.2.15",
  "rand",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core",
 ]
 
 [[package]]
@@ -2324,6 +2366,18 @@ dependencies = [
  "libc",
  "linux-raw-sys",
  "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -2574,7 +2628,9 @@ dependencies = [
  "float-cmp",
  "log",
  "num",
+ "paste",
  "petgraph",
+ "proptest",
  "seal_fhe",
  "serde",
  "serde_json",
@@ -2934,6 +2990,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3000,6 +3062,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,6 +236,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "bigint"
+version = "0.1.0"
+dependencies = [
+ "crypto-bigint",
+ "sunscreen",
+]
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/examples/bigint/Cargo.toml
+++ b/examples/bigint/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "bigint"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+sunscreen = { path = "../../sunscreen" }
+crypto-bigint = "0.4.9"

--- a/examples/bigint/src/main.rs
+++ b/examples/bigint/src/main.rs
@@ -1,0 +1,91 @@
+use crypto_bigint::U256;
+use sunscreen::{
+    fhe_program,
+    types::{bfv::Unsigned256, Cipher},
+    Compiler, Error, Runtime,
+};
+
+/**
+ * The #[fhe_program] macro indicates this function represents an [FHE program].
+ * This basic example multiplies the two operands together and returns the result.
+ *
+ * `Unsigned256` is Sunscreen's unsigned 256-bit integer type compatible with FHE programs.
+ *
+ * The `Cipher<T>` type indicates that type `T` is encrypted, thus `Cipher<Unsigned256>`
+ * is an encrypted [`Unsigned256`] value.
+ *
+ * We'll pass our [`fhe_program`] the compiler, which will transform it into a form
+ * suitable for execution.
+ */
+#[fhe_program(scheme = "bfv")]
+fn mul(a: Cipher<Unsigned256>, b: Cipher<Unsigned256>) -> Cipher<Unsigned256> {
+    a * b
+}
+
+fn main() -> Result<(), Error> {
+    /*
+     * Here we compile the FHE program we previously declared. In the first step,
+     * we create our compiler, specify that we want to compile
+     * `mul`, and build it with the default settings.
+     *
+     * The `?` operator is Rust's standard
+     * error handling mechanism; it returns from the current function (`main`)
+     * when an error occurs (shouldn't happen).
+     *
+     * On success, compilation returns an [`Application`], which
+     * stores a group of FHE programs compiled under the same scheme parameters.
+     * These parameters are an implementation detail of FHE.
+     * While Sunscreen allows experts to explicitly set the scheme parameters,
+     * we're using the default behavior: automatically choose parameters
+     * yielding good performance while maintaining correctness.
+     */
+    let app = Compiler::new().fhe_program(mul).compile()?;
+
+    /*
+     * Next, we construct a runtime, which provides the APIs for encryption,
+     * decryption, and running an FHE program. We need to pass
+     * the scheme parameters our compiler chose.
+     */
+    let runtime = Runtime::new_fhe(app.params())?;
+
+    /*
+     * Here, we generate a public and private key pair. Normally, Alice does this,
+     * sending the public key to bob, who then runs a computation.
+     */
+    let (public_key, private_key) = runtime.generate_keys()?;
+
+    /*
+     * We can create `Unsigned256` values from `u64` literals.
+     */
+    let a = runtime.encrypt(Unsigned256::from(20), &public_key)?;
+
+    /*
+     * Or from the underlying `crypto_bigint::U256` representation. Below is a
+     * representation of 10^18.
+     */
+    let bigint: U256 = U256::from_words([0x0de0b6b3a7640000, 0x0, 0x0, 0x0]);
+    let b = runtime.encrypt(Unsigned256::from(bigint), &public_key)?;
+
+    /*
+     * Now, we run the FHE program with our arguments. This produces a results
+     * `Vec` containing the encrypted outputs of the FHE program.
+     */
+    let results = runtime.run(app.get_fhe_program(mul).unwrap(), vec![a, b], &public_key)?;
+
+    /*
+     * Finally, we decrypt our program's output so we can check it. Our FHE
+     * program outputs a `Unsigned256` single value as the result, so we just take
+     * the first element.
+     */
+    let c: Unsigned256 = runtime.decrypt(&results[0], &private_key)?;
+
+    /*
+     * Assert the multiplication was performed properly.
+     */
+    assert_eq!(c, 20 * Unsigned256::from(bigint));
+
+    // Just assurance that we indeed made use of a big integer.
+    assert!(U256::from(c).bits_vartime() > 64);
+
+    Ok(())
+}

--- a/sunscreen/Cargo.toml
+++ b/sunscreen/Cargo.toml
@@ -24,6 +24,7 @@ bumpalo = "3.8.0"
 crypto-bigint = "0.4.9"
 log = "0.4.14"
 num = "0.4.0"
+paste = "1.0.12"
 petgraph = "0.6.0"
 sunscreen_compiler_common = { path = "../sunscreen_compiler_common" }
 sunscreen_compiler_macros = { version = "0.7", path = "../sunscreen_compiler_macros" }
@@ -48,7 +49,6 @@ sunscreen_compiler_common = { path = "../sunscreen_compiler_common" }
 serde_json = "1.0.74"
 float-cmp = "0.9.0"
 proptest = "1.1.0"
-paste = "1.0.12"
 
 [features]
 bulletproofs = ["sunscreen_zkp_backend/bulletproofs"]

--- a/sunscreen/Cargo.toml
+++ b/sunscreen/Cargo.toml
@@ -47,6 +47,8 @@ sunscreen_zkp_backend = { path = "../sunscreen_zkp_backend", features = ["bullet
 sunscreen_compiler_common = { path = "../sunscreen_compiler_common" }
 serde_json = "1.0.74"
 float-cmp = "0.9.0"
+proptest = "1.1.0"
+paste = "1.0.12"
 
 [features]
 bulletproofs = ["sunscreen_zkp_backend/bulletproofs"]

--- a/sunscreen/src/types/bfv/mod.rs
+++ b/sunscreen/src/types/bfv/mod.rs
@@ -2,8 +2,10 @@ mod batched;
 mod fractional;
 mod rational;
 mod signed;
+mod unsigned;
 
 pub use batched::*;
 pub use fractional::*;
 pub use rational::*;
 pub use signed::*;
+pub use unsigned::*;

--- a/sunscreen/src/types/bfv/unsigned.rs
+++ b/sunscreen/src/types/bfv/unsigned.rs
@@ -1,0 +1,541 @@
+use crypto_bigint::{UInt, Wrapping};
+use seal_fhe::Plaintext as SealPlaintext;
+
+use crate as sunscreen;
+use crate::{
+    fhe::{with_fhe_ctx, FheContextOps},
+    types::{
+        ops::{
+            GraphCipherAdd, GraphCipherConstAdd, GraphCipherConstMul, GraphCipherConstSub,
+            GraphCipherMul, GraphCipherPlainAdd, GraphCipherPlainMul, GraphCipherPlainSub,
+            GraphCipherSub, GraphConstCipherSub, GraphPlainCipherSub,
+        },
+        Cipher,
+    },
+};
+use crate::{
+    types::{intern::FheProgramNode, BfvType, FheType, TypeNameInstance},
+    FheProgramInputTrait, Params, TypeName as DeriveTypeName, WithContext,
+};
+
+use sunscreen_runtime::{
+    InnerPlaintext, NumCiphertexts, Plaintext, TryFromPlaintext, TryIntoPlaintext,
+};
+
+use std::ops::*;
+
+// TODO lil macro to gen all the ones from crypto_bigint
+// TODO tests in sunscreen/tests dir
+
+/// Unsigned 64 bit integer
+pub type Unsigned64 = Unsigned<1>;
+/// Unsigned 128 bit integer
+pub type Unsigned128 = Unsigned<2>;
+/// Unsigned 256 bit integer
+pub type Unsigned256 = Unsigned<4>;
+
+#[derive(Debug, Clone, Copy, DeriveTypeName, PartialEq, Eq)]
+/**
+ * A single unsigned integer.
+ */
+pub struct Unsigned<const LIMBS: usize> {
+    val: UInt<LIMBS>,
+}
+
+impl<const LIMBS: usize> NumCiphertexts for Unsigned<LIMBS> {
+    const NUM_CIPHERTEXTS: usize = 1;
+}
+
+impl<const LIMBS: usize> FheProgramInputTrait for Unsigned<LIMBS> {}
+impl<const LIMBS: usize> FheType for Unsigned<LIMBS> {}
+impl<const LIMBS: usize> BfvType for Unsigned<LIMBS> {}
+
+impl<const LIMBS: usize> std::fmt::Display for Unsigned<LIMBS> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.val)
+    }
+}
+
+impl<const LIMBS: usize> Default for Unsigned<LIMBS> {
+    fn default() -> Self {
+        Self::from(UInt::ZERO)
+    }
+}
+
+impl<const LIMBS: usize> TryIntoPlaintext for Unsigned<LIMBS> {
+    fn try_into_plaintext(
+        &self,
+        params: &Params,
+    ) -> std::result::Result<Plaintext, sunscreen_runtime::Error> {
+        let mut seal_plaintext = SealPlaintext::new()?;
+
+        let sig_bits = self.val.bits_vartime();
+        seal_plaintext.resize(sig_bits);
+
+        for i in 0..sig_bits {
+            let bit_value = self.val.bit_vartime(i);
+            seal_plaintext.set_coefficient(i, bit_value);
+        }
+
+        Ok(Plaintext {
+            data_type: self.type_name_instance(),
+            inner: InnerPlaintext::Seal(vec![WithContext {
+                params: params.clone(),
+                data: seal_plaintext,
+            }]),
+        })
+    }
+}
+
+impl<const LIMBS: usize> TryFromPlaintext for Unsigned<LIMBS> {
+    fn try_from_plaintext(
+        plaintext: &Plaintext,
+        _params: &Params,
+    ) -> std::result::Result<Self, sunscreen_runtime::Error> {
+        let val = match &plaintext.inner {
+            InnerPlaintext::Seal(p) => {
+                if p.len() != 1 {
+                    return Err(sunscreen_runtime::Error::IncorrectCiphertextCount);
+                }
+
+                let bits = usize::min(std::mem::size_of::<UInt<LIMBS>>() * 8, p[0].len());
+
+                let mut val = UInt::ZERO;
+                for i in 0..bits {
+                    let coeff = p[0].get_coefficient(i);
+                    val = wrapping_add(
+                        val,
+                        wrapping_mul(UInt::from_u8(0x1) << i, UInt::from_u64(coeff)),
+                    );
+                }
+
+                // Not sure why below doesn't work? It overflows the first limb
+                // on bit 63. Perhaps above implementation is acceptable.
+
+                //let mut limbs: [u64; LIMBS] = [0; LIMBS];
+                //let limbsize = std::mem::size_of::<Limb>() * 8;
+                //assert_eq!(limbsize, 64); // TODO remove
+
+                //for i in 0..bits {
+                //let coeff = p[0].get_coefficient(i);
+                //limbs[i / limbsize] += (0x1u64 << (i % limbsize)) * coeff;
+                //}
+
+                //Implicit compile-time guarantee that Limb is u64
+                //let val = UInt::from_words(limbs);
+                Self { val }
+            }
+        };
+
+        Ok(val)
+    }
+}
+
+impl<const LIMBS: usize> From<UInt<LIMBS>> for Unsigned<LIMBS> {
+    fn from(val: UInt<LIMBS>) -> Self {
+        Self { val }
+    }
+}
+
+// TODO macro to add the same from_* methods that exists on UInt
+impl<const LIMBS: usize> From<u64> for Unsigned<LIMBS> {
+    fn from(n: u64) -> Self {
+        Self {
+            val: UInt::from_u64(n),
+        }
+    }
+}
+
+impl<const LIMBS: usize> From<Unsigned<LIMBS>> for UInt<LIMBS> {
+    fn from(unsigned: Unsigned<LIMBS>) -> Self {
+        unsigned.val
+    }
+}
+
+// TODO just wrapping for now. would it be preferable to panic on overflow?
+// This would be a departure from bfv::signed.
+fn wrapping_add<const LIMBS: usize>(lhs: UInt<LIMBS>, rhs: UInt<LIMBS>) -> UInt<LIMBS> {
+    (Wrapping(lhs) + Wrapping(rhs)).0
+}
+fn wrapping_mul<const LIMBS: usize>(lhs: UInt<LIMBS>, rhs: UInt<LIMBS>) -> UInt<LIMBS> {
+    (Wrapping(lhs) * Wrapping(rhs)).0
+}
+fn wrapping_sub<const LIMBS: usize>(lhs: UInt<LIMBS>, rhs: UInt<LIMBS>) -> UInt<LIMBS> {
+    (Wrapping(lhs) - Wrapping(rhs)).0
+}
+
+impl<const LIMBS: usize> Add for Unsigned<LIMBS> {
+    type Output = Self;
+
+    fn add(self, rhs: Unsigned<LIMBS>) -> Self::Output {
+        Self::Output {
+            val: wrapping_add(self.val, rhs.val),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Add<UInt<LIMBS>> for Unsigned<LIMBS> {
+    type Output = Self;
+
+    fn add(self, rhs: UInt<LIMBS>) -> Self::Output {
+        Self {
+            val: wrapping_add(self.val, rhs),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Add<Unsigned<LIMBS>> for UInt<LIMBS> {
+    type Output = Unsigned<LIMBS>;
+
+    fn add(self, rhs: Self::Output) -> Self::Output {
+        Self::Output {
+            val: wrapping_add(self, rhs.val),
+        }
+    }
+}
+
+// god we need macros here
+
+impl<const LIMBS: usize> Add<u64> for Unsigned<LIMBS> {
+    type Output = Self;
+
+    fn add(self, rhs: u64) -> Self::Output {
+        Self {
+            val: wrapping_add(self.val, UInt::from_u64(rhs)),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Add<Unsigned<LIMBS>> for u64 {
+    type Output = Unsigned<LIMBS>;
+
+    fn add(self, rhs: Self::Output) -> Self::Output {
+        Self::Output {
+            val: wrapping_add(UInt::from_u64(self), rhs.val),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Mul for Unsigned<LIMBS> {
+    type Output = Self;
+
+    fn mul(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            val: wrapping_mul(self.val, rhs.val),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Mul<UInt<LIMBS>> for Unsigned<LIMBS> {
+    type Output = Self;
+
+    fn mul(self, rhs: UInt<LIMBS>) -> Self::Output {
+        Self {
+            val: wrapping_mul(self.val, rhs),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Mul<Unsigned<LIMBS>> for UInt<LIMBS> {
+    type Output = Unsigned<LIMBS>;
+
+    fn mul(self, rhs: Self::Output) -> Self::Output {
+        Self::Output {
+            val: wrapping_mul(self, rhs.val),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Mul<u64> for Unsigned<LIMBS> {
+    type Output = Self;
+
+    fn mul(self, rhs: u64) -> Self::Output {
+        Self {
+            val: wrapping_mul(self.val, UInt::from_u64(rhs)),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Mul<Unsigned<LIMBS>> for u64 {
+    type Output = Unsigned<LIMBS>;
+
+    fn mul(self, rhs: Self::Output) -> Self::Output {
+        Self::Output {
+            val: wrapping_mul(UInt::from_u64(self), rhs.val),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Sub for Unsigned<LIMBS> {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        Self::Output {
+            val: wrapping_sub(self.val, rhs.val),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Sub<UInt<LIMBS>> for Unsigned<LIMBS> {
+    type Output = Self;
+
+    fn sub(self, rhs: UInt<LIMBS>) -> Self::Output {
+        Self {
+            val: wrapping_sub(self.val, rhs),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Sub<Unsigned<LIMBS>> for UInt<LIMBS> {
+    type Output = Unsigned<LIMBS>;
+
+    fn sub(self, rhs: Self::Output) -> Self::Output {
+        Self::Output {
+            val: wrapping_sub(self, rhs.val),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Sub<u64> for Unsigned<LIMBS> {
+    type Output = Self;
+
+    fn sub(self, rhs: u64) -> Self::Output {
+        Self {
+            val: wrapping_sub(self.val, UInt::from_u64(rhs)),
+        }
+    }
+}
+
+impl<const LIMBS: usize> Sub<Unsigned<LIMBS>> for u64 {
+    type Output = Unsigned<LIMBS>;
+
+    fn sub(self, rhs: Self::Output) -> Self::Output {
+        Self::Output {
+            val: wrapping_sub(UInt::from_u64(self), rhs.val),
+        }
+    }
+}
+
+impl<const LIMBS: usize> GraphCipherAdd for Unsigned<LIMBS> {
+    type Left = Self;
+    type Right = Self;
+
+    fn graph_cipher_add(
+        a: FheProgramNode<Cipher<Self::Left>>,
+        b: FheProgramNode<Cipher<Self::Right>>,
+    ) -> FheProgramNode<Cipher<Self::Left>> {
+        with_fhe_ctx(|ctx| {
+            let n = ctx.add_addition(a.ids[0], b.ids[0]);
+
+            FheProgramNode::new(&[n])
+        })
+    }
+}
+
+impl<const LIMBS: usize> GraphCipherPlainAdd for Unsigned<LIMBS> {
+    type Left = Self;
+    type Right = Self;
+
+    fn graph_cipher_plain_add(
+        a: FheProgramNode<Cipher<Self::Left>>,
+        b: FheProgramNode<Self::Right>,
+    ) -> FheProgramNode<Cipher<Self::Left>> {
+        with_fhe_ctx(|ctx| {
+            let n = ctx.add_addition_plaintext(a.ids[0], b.ids[0]);
+
+            FheProgramNode::new(&[n])
+        })
+    }
+}
+
+impl<const LIMBS: usize> GraphCipherConstAdd for Unsigned<LIMBS> {
+    type Left = Self;
+    type Right = UInt<LIMBS>;
+
+    fn graph_cipher_const_add(
+        a: FheProgramNode<Cipher<Self::Left>>,
+        b: UInt<LIMBS>,
+    ) -> FheProgramNode<Cipher<Self::Left>> {
+        with_fhe_ctx(|ctx| {
+            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
+
+            let lit = ctx.add_plaintext_literal(b.inner);
+            let add = ctx.add_addition_plaintext(a.ids[0], lit);
+
+            FheProgramNode::new(&[add])
+        })
+    }
+}
+
+impl<const LIMBS: usize> GraphCipherSub for Unsigned<LIMBS> {
+    type Left = Self;
+    type Right = Self;
+
+    fn graph_cipher_sub(
+        a: FheProgramNode<Cipher<Self::Left>>,
+        b: FheProgramNode<Cipher<Self::Right>>,
+    ) -> FheProgramNode<Cipher<Self::Left>> {
+        with_fhe_ctx(|ctx| {
+            let n = ctx.add_subtraction(a.ids[0], b.ids[0]);
+
+            FheProgramNode::new(&[n])
+        })
+    }
+}
+
+impl<const LIMBS: usize> GraphCipherPlainSub for Unsigned<LIMBS> {
+    type Left = Self;
+    type Right = Self;
+
+    fn graph_cipher_plain_sub(
+        a: FheProgramNode<Cipher<Self::Left>>,
+        b: FheProgramNode<Self::Right>,
+    ) -> FheProgramNode<Cipher<Self::Left>> {
+        with_fhe_ctx(|ctx| {
+            let n = ctx.add_subtraction_plaintext(a.ids[0], b.ids[0]);
+
+            FheProgramNode::new(&[n])
+        })
+    }
+}
+
+impl<const LIMBS: usize> GraphPlainCipherSub for Unsigned<LIMBS> {
+    type Left = Self;
+    type Right = Self;
+
+    fn graph_plain_cipher_sub(
+        a: FheProgramNode<Self::Left>,
+        b: FheProgramNode<Cipher<Self::Right>>,
+    ) -> FheProgramNode<Cipher<Self::Left>> {
+        with_fhe_ctx(|ctx| {
+            let n = ctx.add_subtraction_plaintext(b.ids[0], a.ids[0]);
+            let n = ctx.add_negate(n);
+
+            FheProgramNode::new(&[n])
+        })
+    }
+}
+
+impl<const LIMBS: usize> GraphCipherConstSub for Unsigned<LIMBS> {
+    type Left = Self;
+    type Right = UInt<LIMBS>;
+
+    fn graph_cipher_const_sub(
+        a: FheProgramNode<Cipher<Self::Left>>,
+        b: Self::Right,
+    ) -> FheProgramNode<Cipher<Self::Left>> {
+        with_fhe_ctx(|ctx| {
+            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
+
+            let lit = ctx.add_plaintext_literal(b.inner);
+            let n = ctx.add_subtraction_plaintext(a.ids[0], lit);
+
+            FheProgramNode::new(&[n])
+        })
+    }
+}
+
+impl<const LIMBS: usize> GraphConstCipherSub for Unsigned<LIMBS> {
+    type Left = UInt<LIMBS>;
+    type Right = Self;
+
+    fn graph_const_cipher_sub(
+        a: UInt<LIMBS>,
+        b: FheProgramNode<Cipher<Self::Right>>,
+    ) -> FheProgramNode<Cipher<Self::Right>> {
+        with_fhe_ctx(|ctx| {
+            let a = Self::from(a).try_into_plaintext(&ctx.data).unwrap();
+
+            let lit = ctx.add_plaintext_literal(a.inner);
+            let n = ctx.add_subtraction_plaintext(b.ids[0], lit);
+            let n = ctx.add_negate(n);
+
+            FheProgramNode::new(&[n])
+        })
+    }
+}
+
+impl<const LIMBS: usize> GraphCipherMul for Unsigned<LIMBS> {
+    type Left = Self;
+    type Right = Self;
+
+    fn graph_cipher_mul(
+        a: FheProgramNode<Cipher<Self::Left>>,
+        b: FheProgramNode<Cipher<Self::Right>>,
+    ) -> FheProgramNode<Cipher<Self::Left>> {
+        with_fhe_ctx(|ctx| {
+            let n = ctx.add_multiplication(a.ids[0], b.ids[0]);
+
+            FheProgramNode::new(&[n])
+        })
+    }
+}
+
+impl<const LIMBS: usize> GraphCipherConstMul for Unsigned<LIMBS> {
+    type Left = Self;
+    type Right = UInt<LIMBS>;
+
+    fn graph_cipher_const_mul(
+        a: FheProgramNode<Cipher<Self::Left>>,
+        b: UInt<LIMBS>,
+    ) -> FheProgramNode<Cipher<Self::Left>> {
+        with_fhe_ctx(|ctx| {
+            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
+
+            let lit = ctx.add_plaintext_literal(b.inner);
+            let add = ctx.add_multiplication_plaintext(a.ids[0], lit);
+
+            FheProgramNode::new(&[add])
+        })
+    }
+}
+
+impl<const LIMBS: usize> GraphCipherPlainMul for Unsigned<LIMBS> {
+    type Left = Self;
+    type Right = Self;
+
+    fn graph_cipher_plain_mul(
+        a: FheProgramNode<Cipher<Self::Left>>,
+        b: FheProgramNode<Self::Right>,
+    ) -> FheProgramNode<Cipher<Self::Left>> {
+        with_fhe_ctx(|ctx| {
+            let n = ctx.add_multiplication_plaintext(a.ids[0], b.ids[0]);
+
+            FheProgramNode::new(&[n])
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn can_add_non_fhe() {
+        let a = Unsigned256::from(5);
+        let b = Unsigned256::from(10);
+
+        assert_eq!(a + b, 15.into());
+        assert_eq!(a + 10, 15.into());
+        assert_eq!(10 + a, 15.into());
+    }
+
+    #[test]
+    fn can_mul_non_fhe() {
+        let a = Unsigned64::from(5);
+        let b = Unsigned64::from(10);
+
+        assert_eq!(a * b, 50.into());
+        assert_eq!(a * 10, 50.into());
+        assert_eq!(10 * a, 50.into());
+    }
+
+    #[test]
+    fn can_sub_non_fhe() {
+        let a = Unsigned128::from(5);
+        let b = Unsigned128::from(11);
+
+        assert_eq!(b - a, 6.into());
+        assert_eq!(b - 5, 6.into());
+    }
+}

--- a/sunscreen/src/types/bfv/unsigned.rs
+++ b/sunscreen/src/types/bfv/unsigned.rs
@@ -25,8 +25,6 @@ use crate::{
     FheProgramInputTrait, Params, TypeName as DeriveTypeName, WithContext,
 };
 
-// TODO lil macro to gen all the ones from crypto_bigint?
-
 /// Unsigned 64 bit integer
 pub type Unsigned64 = Unsigned<1>;
 /// Unsigned 128 bit integer

--- a/sunscreen/src/types/bfv/unsigned.rs
+++ b/sunscreen/src/types/bfv/unsigned.rs
@@ -121,20 +121,6 @@ impl<const LIMBS: usize> TryFromPlaintext for Unsigned<LIMBS> {
                     }
                 }
 
-                // Not sure why below doesn't work? It overflows the first limb
-                // on bit 63. Perhaps above implementation is acceptable.
-
-                //let mut limbs: [u64; LIMBS] = [0; LIMBS];
-                //let limbsize = std::mem::size_of::<Limb>() * 8;
-                //assert_eq!(limbsize, 64); // TODO remove
-
-                //for i in 0..bits {
-                //let coeff = p[0].get_coefficient(i);
-                //limbs[i / limbsize] += (0x1u64 << (i % limbsize)) * coeff;
-                //}
-
-                //Implicit compile-time guarantee that Limb is u64
-                //let val = UInt::from_words(limbs);
                 Self { val }
             }
         };
@@ -164,8 +150,6 @@ impl<const LIMBS: usize> From<Unsigned<LIMBS>> for UInt<LIMBS> {
     }
 }
 
-// TODO just wrapping for now. would it be preferable to panic on overflow?
-// This would be a departure from bfv::signed.
 fn wrapping_add<const LIMBS: usize>(lhs: UInt<LIMBS>, rhs: UInt<LIMBS>) -> UInt<LIMBS> {
     (Wrapping(lhs) + Wrapping(rhs)).0
 }

--- a/sunscreen/src/types/intern/fhe_literal.rs
+++ b/sunscreen/src/types/intern/fhe_literal.rs
@@ -1,3 +1,5 @@
+use crypto_bigint::UInt;
+
 /**
  * Tags types (e.g. u64, f64, etc) so they can be used as literals
  * in FHE programs with the GraphCipherConst* traits.
@@ -6,3 +8,4 @@ pub trait FheLiteral {}
 impl FheLiteral for f64 {}
 impl FheLiteral for u64 {}
 impl FheLiteral for i64 {}
+impl<const LIMBS: usize> FheLiteral for UInt<LIMBS> {} // is this true?

--- a/sunscreen/tests/unsigned.rs
+++ b/sunscreen/tests/unsigned.rs
@@ -1,0 +1,80 @@
+use crypto_bigint::U256;
+use paste::paste;
+use proptest::prelude::{prop::num::u64::ANY, prop_assert_eq, proptest, ProptestConfig};
+use sunscreen::{
+    fhe_program,
+    types::{bfv::Unsigned256, Cipher},
+    Compiler, FheApplication, FheProgramInput, FheRuntime, PrivateKey, PublicKey, Runtime,
+};
+
+// Darn, Application is no longer thread safe, no lazy init :(
+// luckily proptest supports something like an expensive setup operation
+// TODO tests for more than just 256?
+
+macro_rules! fhe_program {
+    ($(($op:ident, $binop:tt, $ty:ident)),+) => {
+        $(
+            paste! {
+                #[fhe_program(scheme = "bfv")]
+                fn $op(a: Cipher<$ty>, b: Cipher<$ty>) -> Cipher<$ty> {
+                    a $binop b
+                }
+                #[fhe_program(scheme = "bfv")]
+                fn [<$op _plain>](a: Cipher<$ty>, b: $ty) -> Cipher<$ty> {
+                    a $binop b
+                }
+            }
+        )+
+     };
+}
+
+fhe_program! {
+    (add, +, Unsigned256),
+    (sub, -, Unsigned256),
+    (mul, *, Unsigned256)
+}
+
+struct FheApp {
+    app: FheApplication,
+    rt: FheRuntime,
+    pk: PublicKey,
+    sk: PrivateKey,
+}
+impl FheApp {
+    fn new() -> Self {
+        let app: FheApplication = Compiler::new()
+            .fhe_program(add)
+            .fhe_program(add_plain)
+            .fhe_program(sub)
+            .fhe_program(sub_plain)
+            .fhe_program(mul)
+            .fhe_program(mul_plain)
+            .compile()
+            .unwrap();
+        let rt: FheRuntime = Runtime::new_fhe(app.params()).unwrap();
+        let (pk, sk) = rt.generate_keys().unwrap();
+        Self { app, rt, pk, sk }
+    }
+}
+
+#[test]
+fn add_fhe_proptest() {
+    let FheApp { app, rt, pk, sk } = FheApp::new();
+
+    proptest!(ProptestConfig::with_cases(20), |(lhs in [ANY; 4], rhs in [ANY; 4])| {
+
+        let a = U256::from_words(lhs);
+        let a_c = rt.encrypt(Unsigned256::from(a), &pk).unwrap();
+        let b = U256::from_words(rhs);
+        let b_c = rt.encrypt(Unsigned256::from(b), &pk).unwrap();
+        let args: Vec<FheProgramInput> = vec![a_c.into(), b_c.into()];
+
+        let result = rt
+            .run(app.get_fhe_program(add).unwrap(), args, &pk)
+            .unwrap();
+
+        let c: Unsigned256 = rt.decrypt(&result[0], &sk).unwrap();
+
+        prop_assert_eq!(a.wrapping_add(&b), c.into())
+    });
+}


### PR DESCRIPTION
This should be cleaned up and have some tests in `./sunscreen/tests`. Opening for visibility on initial approach / representation.

Some notable decisions:

1. We just wrap the crypto big ints. If desirable we could add macros to define synonyms and to/from impls for all the `UInt`s that that crate defines. (Also we should probably add some macros for all the boilerplate arithmetic impls before merging).
2. We use wrapping arithmetic, as the current `bfv::Signed` type does (in release mode anyway).