### PR TITLE
Fix 64-bit pointer assumptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2084,9 +2084,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.58"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa1fb82fc0c281dd9671101b66b771ebbe1eaf967b96ac8740dcba4b70005ca8"
+checksum = "6aeca18b86b413c660b781aa319e4e2648a3e6f9eadc9b47e9038e6fe9f3451b"
 dependencies = [
  "unicode-ident",
 ]

--- a/benchmarks/bfv_zkp/src/bfv.rs
+++ b/benchmarks/bfv_zkp/src/bfv.rs
@@ -263,13 +263,13 @@ fn ark_bigint_to_native_field<B: ZkpBackend, F: MontConfig<N>, const N: usize>(
     assert!(N <= 8);
 
     let x = x.into_bigint();
-    let mut out = ZkpBigInt::ZERO;
+    let mut words = [0; 8];
 
-    for (i, l) in x.0.iter().enumerate() {
-        out.0.limbs_mut()[i] = crypto_bigint::Limb(*l);
+    for i in 0..N {
+        words[i] = x.0[i];
     }
 
-    NativeField::from(out)
+    NativeField::from(ZkpBigInt::from_words(words))
 }
 
 type BpBackendField = <BulletproofsBackend as ZkpBackend>::Field;
@@ -310,13 +310,12 @@ fn into_rns_poly<F: MontConfig<N>, const N: usize>(
 }
 
 fn ark_bigint_to_zkp_bigint<const N: usize>(x: BigInt<N>) -> ZkpBigInt {
-    let mut r = ZkpBigInt::ZERO;
-
+    assert!(N <= 8);
+    let mut words = [0; 8];
     for i in 0..N {
-        r.0.as_words_mut()[i] = x.0[i];
+        words[i] = x.0[i];
     }
-
-    r
+    ZkpBigInt::from_words(words)
 }
 
 /**
@@ -332,12 +331,11 @@ fn signed_into_rns_poly<F: MontConfig<N>, const N: usize>(
     let q = ark_bigint_to_zkp_bigint(F::MODULUS);
 
     assert!(N <= 8);
-
-    let mut q = ZkpBigInt::ZERO;
-
+    let mut words = [0; 8];
     for i in 0..N {
-        q.0.as_words_mut()[i] = F::MODULUS.0[i];
+        words[i] = F::MODULUS.0[i];
     }
+    let q = ZkpBigInt::from_words(words);
 
     let offset = BpBackendField::FIELD_MODULUS.wrapping_sub(&q);
 

--- a/examples/bigint/src/main.rs
+++ b/examples/bigint/src/main.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), Error> {
      * Or from the underlying `crypto_bigint::U256` representation. Below is a
      * representation of 10^18.
      */
-    let bigint: U256 = U256::from_words([0x0de0b6b3a7640000, 0x0, 0x0, 0x0]);
+    let bigint: U256 = U256::from_u64(0x0de0b6b3a7640000);
     let b = runtime.encrypt(Unsigned256::from(bigint), &public_key)?;
 
     /*

--- a/sunscreen/src/types/bfv/unsigned.rs
+++ b/sunscreen/src/types/bfv/unsigned.rs
@@ -65,6 +65,7 @@ impl<const LIMBS: usize> TryIntoPlaintext for Unsigned<LIMBS> {
 
         for i in 0..sig_bits {
             let bit_value = self.val.bit_vartime(i);
+            #[allow(clippy::unnecessary_cast)]
             seal_plaintext.set_coefficient(i, bit_value as u64);
         }
 

--- a/sunscreen/src/types/bfv/unsigned.rs
+++ b/sunscreen/src/types/bfv/unsigned.rs
@@ -1,6 +1,6 @@
 use std::ops::*;
 
-use crypto_bigint::{UInt, Wrapping};
+use crypto_bigint::{nlimbs, UInt, Wrapping};
 use paste::paste;
 use seal_fhe::Plaintext as SealPlaintext;
 
@@ -24,13 +24,6 @@ use crate::{
     types::{intern::FheProgramNode, BfvType, FheType, TypeNameInstance},
     FheProgramInputTrait, Params, TypeName as DeriveTypeName, WithContext,
 };
-
-/// Unsigned 64 bit integer
-pub type Unsigned64 = Unsigned<1>;
-/// Unsigned 128 bit integer
-pub type Unsigned128 = Unsigned<2>;
-/// Unsigned 256 bit integer
-pub type Unsigned256 = Unsigned<4>;
 
 #[derive(Debug, Clone, Copy, DeriveTypeName, PartialEq, Eq)]
 /**
@@ -72,7 +65,7 @@ impl<const LIMBS: usize> TryIntoPlaintext for Unsigned<LIMBS> {
 
         for i in 0..sig_bits {
             let bit_value = self.val.bit_vartime(i);
-            seal_plaintext.set_coefficient(i, bit_value);
+            seal_plaintext.set_coefficient(i, bit_value as u64);
         }
 
         Ok(Plaintext {
@@ -319,6 +312,21 @@ impl<const LIMBS: usize> GraphPlainCipherSub for Unsigned<LIMBS> {
             FheProgramNode::new(&[n])
         })
     }
+}
+
+macro_rules! type_synonyms {
+    ($($bits:expr),+) => {
+        $(
+            paste! {
+                #[doc= concat!("Unsigned ", stringify!($bits), "-bit integer")]
+                pub type [<Unsigned $bits>] = Unsigned<{nlimbs!($bits)}>;
+            }
+        )+
+    };
+}
+
+type_synonyms! {
+    64, 128, 256, 512
 }
 
 #[cfg(test)]

--- a/sunscreen_zkp_backend/src/lib.rs
+++ b/sunscreen_zkp_backend/src/lib.rs
@@ -204,7 +204,32 @@ impl BigInt {
      * Create a [`BigInt`] from the given limbs.
      */
     pub const fn from_words(val: [u64; 8]) -> Self {
-        Self(U512::from_words(val))
+        #[cfg(target_pointer_width = "64")]
+        {
+            Self(U512::from_words(val))
+        }
+
+        #[cfg(target_pointer_width = "32")]
+        {
+            Self(U512::from_words([
+                val[0] as u32,
+                (val[0] >> 32) as u32,
+                val[1] as u32,
+                (val[1] >> 32) as u32,
+                val[2] as u32,
+                (val[2] >> 32) as u32,
+                val[3] as u32,
+                (val[3] >> 32) as u32,
+                val[4] as u32,
+                (val[4] >> 32) as u32,
+                val[5] as u32,
+                (val[5] >> 32) as u32,
+                val[6] as u32,
+                (val[6] >> 32) as u32,
+                val[7] as u32,
+                (val[7] >> 32) as u32,
+            ]))
+        }
     }
 
     /**


### PR DESCRIPTION
We'll still need the `syn`/`proc-macro2` fixes to get `build --target wasm32-unknown-emscripten` working. This fixes all the other issues.

We still have some issues for wasm when gated behind e.g. `test`, but I'm punting on that, just wanted to get these in for now.