### PR TITLE
Offer a simpler API for runtime creation

### DIFF
--- a/examples/amm/src/main.rs
+++ b/examples/amm/src/main.rs
@@ -2,7 +2,6 @@ use sunscreen::{
     fhe_program,
     types::{bfv::Rational, Cipher},
     Ciphertext, CompiledFheProgram, Compiler, Error, FheRuntime, Params, PrivateKey, PublicKey,
-    Runtime,
 };
 
 #[fhe_program(scheme = "bfv")]
@@ -28,7 +27,7 @@ impl Miner {
     pub fn setup() -> Result<Miner, Error> {
         let app = Compiler::new().fhe_program(swap_nu).compile()?;
 
-        let runtime = Runtime::new_fhe(app.params())?;
+        let runtime = FheRuntime::new(app.params())?;
 
         Ok(Miner {
             compiled_swap_nu: app.get_fhe_program(swap_nu).unwrap().clone(),
@@ -63,7 +62,7 @@ struct Alice {
 
 impl Alice {
     pub fn setup(params: &Params) -> Result<Alice, Error> {
-        let runtime = Runtime::new_fhe(params)?;
+        let runtime = FheRuntime::new(params)?;
 
         let (public_key, private_key) = runtime.generate_keys()?;
 

--- a/examples/bigint/src/main.rs
+++ b/examples/bigint/src/main.rs
@@ -2,7 +2,7 @@ use crypto_bigint::U256;
 use sunscreen::{
     fhe_program,
     types::{bfv::Unsigned256, Cipher},
-    Compiler, Error, Runtime,
+    Compiler, Error, FheRuntime,
 };
 
 /**
@@ -46,7 +46,7 @@ fn main() -> Result<(), Error> {
      * decryption, and running an FHE program. We need to pass
      * the scheme parameters our compiler chose.
      */
-    let runtime = Runtime::new_fhe(app.params())?;
+    let runtime = FheRuntime::new(app.params())?;
 
     /*
      * Here, we generate a public and private key pair. Normally, Alice does this,

--- a/examples/calculator_fractional/src/main.rs
+++ b/examples/calculator_fractional/src/main.rs
@@ -6,9 +6,9 @@ use std::thread::{self, JoinHandle};
 use sunscreen::{
     fhe_program,
     types::{bfv::Fractional, Cipher},
-    Ciphertext, Compiler, Params, PlainModulusConstraint, PublicKey, Runtime, RuntimeError,
+    Ciphertext, Compiler, FheApplication, FheRuntime, Params, PlainModulusConstraint, PublicKey,
+    RuntimeError,
 };
-use sunscreen::{FheApplication, FheRuntime};
 
 fn help() {
     println!("This is a privacy preserving calculator. You can add, subtract, multiply, divide decimal values. The operation is sent to Bob in cleartext while the operands
@@ -145,7 +145,7 @@ fn alice(
         // Bob needs to send us the scheme parameters compatible with his FHE programs.
         let params = recv_params.recv().unwrap();
 
-        let runtime = Runtime::new_fhe(&params).unwrap();
+        let runtime = FheRuntime::new(&params).unwrap();
 
         let (public_key, private_key) = runtime.generate_keys().unwrap();
 
@@ -247,7 +247,7 @@ fn bob(
 
         let public_key = recv_pub.recv().unwrap();
 
-        let runtime = Runtime::new_fhe(app.params()).unwrap();
+        let runtime = FheRuntime::new(app.params()).unwrap();
 
         let mut ans = runtime
             .encrypt(Fractional::<64>::try_from(0f64).unwrap(), &public_key)

--- a/examples/calculator_rational/src/main.rs
+++ b/examples/calculator_rational/src/main.rs
@@ -7,8 +7,7 @@ use sunscreen::FheRuntime;
 use sunscreen::{
     fhe_program,
     types::{bfv::Rational, Cipher},
-    Ciphertext, Compiler, FheApplication, Params, PlainModulusConstraint, PublicKey, Runtime,
-    RuntimeError,
+    Ciphertext, Compiler, FheApplication, Params, PlainModulusConstraint, PublicKey, RuntimeError,
 };
 
 fn help() {
@@ -128,7 +127,7 @@ fn alice(
         // Bob needs to send us the scheme parameters compatible with his FHE program.
         let params = recv_params.recv().unwrap();
 
-        let runtime = Runtime::new_fhe(&params).unwrap();
+        let runtime = FheRuntime::new(&params).unwrap();
 
         let (public_key, private_key) = runtime.generate_keys().unwrap();
 
@@ -238,7 +237,7 @@ fn bob(
 
         let public_key = recv_pub.recv().unwrap();
 
-        let runtime = Runtime::new_fhe(app.params()).unwrap();
+        let runtime = FheRuntime::new(app.params()).unwrap();
 
         let mut ans = runtime
             .encrypt(Rational::try_from(0f64).unwrap(), &public_key)

--- a/examples/chi_sq/src/main.rs
+++ b/examples/chi_sq/src/main.rs
@@ -17,7 +17,7 @@ use sunscreen::{
         bfv::{Batched, Signed},
         Cipher, FheType, TypeName,
     },
-    Compiler, Error, FheProgramFn, FheProgramInput, PlainModulusConstraint, Runtime,
+    Compiler, Error, FheProgramFn, FheProgramInput, FheRuntime, PlainModulusConstraint,
 };
 
 use std::marker::PhantomData;
@@ -181,7 +181,7 @@ where
 
     println!("\t\tCompile time {elapsed}s");
 
-    let runtime = Runtime::new_fhe(app.params())?;
+    let runtime = FheRuntime::new(app.params())?;
 
     let n_0 = U::from(n_0);
     let n_1 = U::from(n_1);

--- a/examples/dot_prod/src/main.rs
+++ b/examples/dot_prod/src/main.rs
@@ -5,7 +5,7 @@
 use sunscreen::{
     fhe_program,
     types::{bfv::Batched, Cipher, LaneCount, SwapRows},
-    Compiler, FheProgramInput, PlainModulusConstraint, Runtime,
+    Compiler, FheProgramInput, FheRuntime, PlainModulusConstraint,
 };
 
 use std::ops::*;
@@ -164,7 +164,7 @@ fn main() -> Result<(), sunscreen::Error> {
 
     println!("Compiled in {}s", end.as_secs_f64());
 
-    let runtime = Runtime::new_fhe(app.params())?;
+    let runtime = FheRuntime::new(app.params())?;
 
     let (public_key, private_key) = runtime.generate_keys()?;
     let a_enc = runtime.encrypt(a_batched, &public_key)?;

--- a/examples/mean_variance/src/main.rs
+++ b/examples/mean_variance/src/main.rs
@@ -4,7 +4,7 @@ use sunscreen::{
     fhe_program,
     types::{bfv::Fractional, Cipher},
     Ciphertext, CompiledFheProgram, Compiler, Error as SunscreenError, FheRuntime, Params,
-    PrivateKey, PublicKey, Runtime, RuntimeError,
+    PrivateKey, PublicKey, RuntimeError,
 };
 
 const DATA_POINTS: usize = 15;
@@ -89,7 +89,7 @@ impl Bob {
         let mean_program = app.get_fhe_program(mean_fhe).unwrap();
         let variance_program = app.get_fhe_program(variance_fhe).unwrap();
 
-        let runtime = Runtime::new_fhe(app.params())?;
+        let runtime = FheRuntime::new(app.params())?;
 
         Ok(Self {
             params: app.params().to_owned(),
@@ -135,7 +135,7 @@ pub struct Alice {
 impl Alice {
     pub fn new(serialized_params: &[u8]) -> Result<Self, Error> {
         let params = bincode::deserialize(serialized_params)?;
-        let runtime = Runtime::new_fhe(&params)?;
+        let runtime = FheRuntime::new(&params)?;
 
         let (public_key, private_key) = runtime.generate_keys()?;
 

--- a/examples/pir/src/main.rs
+++ b/examples/pir/src/main.rs
@@ -4,7 +4,7 @@ use sunscreen::{
     fhe_program,
     types::{bfv::Signed, Cipher},
     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, FheRuntime, Params,
-    PrivateKey, PublicKey, Runtime,
+    PrivateKey, PublicKey,
 };
 
 const SQRT_DATABASE_SIZE: usize = 10;
@@ -57,7 +57,7 @@ impl Server {
     pub fn setup() -> Result<Server, Error> {
         let app = Compiler::new().fhe_program(lookup).compile()?;
 
-        let runtime = Runtime::new_fhe(app.params())?;
+        let runtime = FheRuntime::new(app.params())?;
 
         Ok(Server {
             compiled_lookup: app.get_fhe_program(lookup).unwrap().clone(),
@@ -105,7 +105,7 @@ struct Alice {
 
 impl Alice {
     pub fn setup(params: &Params) -> Result<Alice, Error> {
-        let runtime = Runtime::new_fhe(params)?;
+        let runtime = FheRuntime::new(params)?;
 
         let (public_key, private_key) = runtime.generate_keys()?;
 

--- a/examples/simple_multiply/src/main.rs
+++ b/examples/simple_multiply/src/main.rs
@@ -1,7 +1,7 @@
 use sunscreen::{
     fhe_program,
     types::{bfv::Signed, Cipher},
-    Compiler, Error, Runtime,
+    Compiler, Error, FheRuntime,
 };
 
 /**
@@ -46,7 +46,7 @@ fn main() -> Result<(), Error> {
      * decryption, and running an FHE program. We need to pass
      * the scheme parameters our compiler chose.
      */
-    let runtime = Runtime::new_fhe(app.params())?;
+    let runtime = FheRuntime::new(app.params())?;
 
     /*
      * Here, we generate a public and private key pair. Normally, Alice does this,

--- a/sunscreen/benches/smart_fhe.rs
+++ b/sunscreen/benches/smart_fhe.rs
@@ -3,7 +3,7 @@ use std::time::Instant;
 use sunscreen::{
     fhe_program,
     types::{bfv::Fractional, Cipher},
-    Compiler, FheProgramInput, Params, Runtime, SchemeType,
+    Compiler, FheProgramInput, FheRuntime, Params, SchemeType,
 };
 
 /// This program benchmarks all the FHE pieces of private transactions with
@@ -55,7 +55,7 @@ fn benchmark(params: &Params) {
 
         compile_time += now.elapsed().as_secs_f64();
 
-        let runtime = Runtime::new_fhe(params).unwrap();
+        let runtime = FheRuntime::new(params).unwrap();
 
         let now = Instant::now();
         let (public, private) = runtime.generate_keys().unwrap();

--- a/sunscreen/crates-io.md
+++ b/sunscreen/crates-io.md
@@ -4,7 +4,7 @@ Sunscreen is an ecosystem for building privacy-preserving applications using ful
 
 This project is licensed under the terms of the GNU AGPLv3 license. If you require a different license for your application, please reach out to us.
 
-*WARNING!* This library is meant for experiments only. It has not been externally audited and is *not* intended for use in production. 
+*WARNING!* This library is meant for experiments only. It has not been externally audited and is *not* intended for use in production.
 
 # Example
 Below, we look at how to multiply two encrypted integers together.
@@ -13,7 +13,7 @@ Below, we look at how to multiply two encrypted integers together.
 use sunscreen::{
     fhe_program,
     types::{bfv::Signed, Cipher},
-    Compiler, Error, Runtime,
+    Compiler, Error, FheRuntime,
 };
 
 #[fhe_program(scheme = "bfv")]
@@ -26,7 +26,7 @@ fn main() -> Result<(), Error> {
         .fhe_program(simple_multiply)
         .compile()?;
 
-    let runtime = Runtime::new_fhe(app.params())?;
+    let runtime = FheRuntime::new(app.params())?;
 
     let (public_key, private_key) = runtime.generate_keys()?;
 

--- a/sunscreen/src/lib.rs
+++ b/sunscreen/src/lib.rs
@@ -7,7 +7,7 @@
 //! # Examples
 //! This example is further annotated in `examples/simple_multiply`.
 //! ```
-//! # use sunscreen::{fhe_program, Compiler, types::{bfv::Signed, Cipher}, PlainModulusConstraint, Params, Runtime};
+//! # use sunscreen::{fhe_program, Compiler, types::{bfv::Signed, Cipher}, PlainModulusConstraint, Params, FheRuntime};
 //!
 //! #[fhe_program(scheme = "bfv")]
 //! fn simple_multiply(a: Cipher<Signed>, b: Cipher<Signed>) -> Cipher<Signed> {
@@ -22,7 +22,7 @@
 //!       .compile()
 //!       .unwrap();
 //!
-//!   let runtime = Runtime::new_fhe(app.params()).unwrap();
+//!   let runtime = FheRuntime::new(app.params()).unwrap();
 //!
 //!   let (public_key, private_key) = runtime.generate_keys().unwrap();
 //!

--- a/sunscreen/tests/unsigned.rs
+++ b/sunscreen/tests/unsigned.rs
@@ -8,7 +8,7 @@ use sunscreen::{
         bfv::{Unsigned, Unsigned256},
         Cipher,
     },
-    Compiler, FheApplication, FheProgramInput, FheRuntime, PrivateKey, PublicKey, Runtime,
+    Compiler, FheApplication, FheProgramInput, FheRuntime, PrivateKey, PublicKey,
 };
 
 macro_rules! fhe_program {
@@ -51,7 +51,7 @@ impl FheApp {
             .fhe_program(mul_plain)
             .compile()
             .unwrap();
-        let rt: FheRuntime = Runtime::new_fhe(app.params()).unwrap();
+        let rt: FheRuntime = FheRuntime::new(app.params()).unwrap();
         let (pk, sk) = rt.generate_keys().unwrap();
         Self { app, rt, pk, sk }
     }

--- a/sunscreen_docs/src/advanced/batching/dot_product.md
+++ b/sunscreen_docs/src/advanced/batching/dot_product.md
@@ -22,7 +22,7 @@ fn dot_product(a: &[i64], b: &[i64]) -> i64 {
 #   let b = (10..20).into_iter().collect::<Vec<i64>>();
 #
 #   let c = dot_product(&a, &b);
-#   
+#
 #   println!("{:?} dot {:?} = {}", a, b, c);
 # }
 ```
@@ -34,7 +34,7 @@ First, some boilerplate code
 use sunscreen_compiler::{
     fhe_program,
     types::{bfv::Batched, Cipher, LaneCount, SwapRows},
-    Compiler, FheProgramInput, PlainModulusConstraint, Runtime,
+    Compiler, FheProgramInput, FheRuntime, PlainModulusConstraint,
 };
 
 use std::ops::*;
@@ -92,7 +92,7 @@ We're going to write this algorithm [generically](/fhe_programs/plaintext_execut
 use sunscreen_compiler::{
     fhe_program,
     types::{bfv::Batched, Cipher, LaneCount, SwapRows},
-    Compiler, FheProgramInput, PlainModulusConstraint, Runtime,
+    Compiler, FheProgramInput, FheRuntime, PlainModulusConstraint,
 };
 
 use std::ops::*;
@@ -132,7 +132,7 @@ fn main() {
 
 ## Make test data
 
-Next, we'll make some test data. Let's write a function `make_vector` that generates a vector with 8192 elements of the sequence `0..32` repeated and packed as described in the algorithm outline. 
+Next, we'll make some test data. Let's write a function `make_vector` that generates a vector with 8192 elements of the sequence `0..32` repeated and packed as described in the algorithm outline.
 
 ```rust
 fn is_power_of_2(value: usize) -> bool {
@@ -164,7 +164,7 @@ Finally, we'll put it all together to compute a dot product with FHE:
 use sunscreen_compiler::{
     fhe_program,
     types::{bfv::Batched, Cipher, LaneCount, SwapRows},
-    Compiler, FheProgramInput, PlainModulusConstraint, Runtime,
+    Compiler, FheProgramInput, FheRuntime, PlainModulusConstraint,
 };
 
 use std::ops::*;
@@ -241,7 +241,7 @@ fn main() {
         // prime number. `PlainModulusConstraint::BatchingMinimum(24)` says
         // set the plain modulus to be a prime number capable of supporting
         // batching with at least 24 bits of precision. We choose 24 because
-        // the final value of our dot product requires this much integer 
+        // the final value of our dot product requires this much integer
         // precision.
         .plain_modulus_constraint(PlainModulusConstraint::BatchingMinimum(24))
         .compile()
@@ -250,7 +250,7 @@ fn main() {
 
     // 3. Make our runtime, generate keys, encrypt our data, run our
     // program, and check the result
-    let runtime = Runtime::new_fhe(&fhe_program.metadata.params).unwrap();
+    let runtime = FheRuntime::new(&fhe_program.metadata.params).unwrap();
 
     let (public_key, private_key) = runtime.generate_keys().unwrap();
     let a_enc = runtime.encrypt(a_batched, &public_key).unwrap();

--- a/sunscreen_docs/src/advanced/pruning_keys.md
+++ b/sunscreen_docs/src/advanced/pruning_keys.md
@@ -1,5 +1,5 @@
 # Pruning public keys
-For convenience, the `generate_keys` function creates several keys in the returned `PublicKey` object. 
+For convenience, the `generate_keys` function creates several keys in the returned `PublicKey` object.
 
 ## Why you might want to prune `PublicKey`
 Some of these keys can be fairly large, the size of which is determined by scheme parameters. However, they may or may not be needed in your application:
@@ -15,7 +15,7 @@ Each compiled FHE program contains a list the keys it needs at runtime in `fhe_p
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Compiler, Runtime, PublicKey
+#     Compiler, FheRuntime, PublicKey
 # };
 #
 # #[fhe_program(scheme = "bfv")]
@@ -28,7 +28,7 @@ Each compiled FHE program contains a list the keys it needs at runtime in `fhe_p
 #        .compile()
 #        .unwrap();
 #
-#    let runtime = Runtime::new_fhe(app.params()).unwrap();
+#    let runtime = FheRuntime::new(app.params()).unwrap();
 let (public_key, private_key) = runtime.generate_keys().unwrap();
 
 // Shadow and overwrite the public_key, removing the galois_key and relin_key

--- a/sunscreen_docs/src/fhe_programs/pir_simple.md
+++ b/sunscreen_docs/src/fhe_programs/pir_simple.md
@@ -1,5 +1,5 @@
 # Warm up: a very simple PIR algorithm
-We'll start with a very simple algorithm that uses a dot product to return an item privately. 
+We'll start with a very simple algorithm that uses a dot product to return an item privately.
 
 ## How will our algorithm work?
 Everything in the database will be *un*encrypted. We'll represent our database as a [vector](https://en.wikipedia.org/wiki/Euclidean_vector) of `n` items.
@@ -8,10 +8,10 @@ Let's say that Alice wants to retrieve the 2nd item from the database. Alice wil
 
 ### Information retrieval (**without privacy**)
  Every element of this query vector, *except* the one Alice is interested in, will have a 0 in its place. Alice will place a 1 in the 2nd entry (since she's interested in the 2nd item). When the server take the dot product of these two vectors, Alice will get back the item she wanted to retrieve:
- 
- [item<sub>1</sub>, item<sub>2</sub>, item<sub>3</sub>, ... , item<sub>n</sub>] &middot; [0, 1, 0, ... , 0]<sup>t</sup> 
 
-= item<sub>1</sub> &middot; 0 + item<sub>2</sub> &middot; 1 + item<sub>3</sub> &middot; 0 + ... + item<sub>n</sub> &middot; 0 
+ [item<sub>1</sub>, item<sub>2</sub>, item<sub>3</sub>, ... , item<sub>n</sub>] &middot; [0, 1, 0, ... , 0]<sup>t</sup>
+
+= item<sub>1</sub> &middot; 0 + item<sub>2</sub> &middot; 1 + item<sub>3</sub> &middot; 0 + ... + item<sub>n</sub> &middot; 0
 
 = item<sub>2</sub>
 
@@ -23,9 +23,9 @@ For simplicity, let Enc(x) denote that we encrypt x.[^1]
 
 Since Alice doesn't want to reveal to the server *which* item she's interested in, she encrypts each of the elements in her query vector with respect to her FHE public key. Voila! We can now retrieve the information privately:
 
-[item<sub>1</sub>, item<sub>2</sub>, item<sub>3</sub>, ... , item<sub>n</sub>] &middot; [Enc(0), Enc(1), Enc(0), ... , Enc(0)]<sup>t</sup> 
+[item<sub>1</sub>, item<sub>2</sub>, item<sub>3</sub>, ... , item<sub>n</sub>] &middot; [Enc(0), Enc(1), Enc(0), ... , Enc(0)]<sup>t</sup>
 
- = item<sub>1</sub> &middot; Enc(0) + item<sub>2</sub> &middot; Enc(1) + item<sub>3</sub> &middot; Enc(0) + ... + item<sub>n</sub> &middot; Enc(0) 
+ = item<sub>1</sub> &middot; Enc(0) + item<sub>2</sub> &middot; Enc(1) + item<sub>3</sub> &middot; Enc(0) + ... + item<sub>n</sub> &middot; Enc(0)
 
 = Enc(item<sub>2</sub>)
 
@@ -70,8 +70,8 @@ We declare our `lookup` function as an FHE program with the appropriate attribut
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, Params, PrivateKey,
-#     PublicKey, Runtime,
+#     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, FheRuntime,
+#     Params, PrivateKey, PublicKey,
 # };
 #
 /// Alice is a party that wants to look up a value in the database without
@@ -84,7 +84,7 @@ struct Alice {
     private_key: PrivateKey,
 
     /// Alice's runtime
-    runtime: Runtime,
+    runtime: FheRuntime,
 }
 ```
 
@@ -94,8 +94,8 @@ Alice wants to retrieve an item from the database privately. She'll need a publi
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, Params, PrivateKey,
-#     PublicKey, Runtime, FheRuntime
+#     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, FheRuntime,
+#     Params, PrivateKey, PublicKey,
 # };
 #
 # const DATABASE_SIZE: usize = 100;
@@ -115,7 +115,7 @@ Alice wants to retrieve an item from the database privately. She'll need a publi
 #
 impl Alice {
     pub fn setup(params: &Params) -> Result<Alice, Error> {
-        let runtime = Runtime::new_fhe(params)?;
+        let runtime = FheRuntime::new(params)?;
 
         let (public_key, private_key) = runtime.generate_keys()?;
 
@@ -145,7 +145,7 @@ impl Alice {
 }
 ```
 
-Alice will need to construct a runtime. Once that's done, she can generate her public/private key pair. 
+Alice will need to construct a runtime. Once that's done, she can generate her public/private key pair.
 
 Alice can create her unencrypted query "vector" (actually an [array](./types/types.md/#array)) of 0's and 1's by calling `create_query`. Recall that the we'll have a 1 in the place of her desired item's index and a 0 elsewhere. Since she wants her query to be private, she'll `encrypt` her `query`, passing in her `public_key` as necessary.
 
@@ -159,8 +159,8 @@ Let's look at the server next.
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, Params, PrivateKey,
-#     PublicKey, Runtime,
+#     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, FheRuntime,
+#     Params, PrivateKey, PublicKey,
 # };
 /// This is the server that processes Alice's query.
 struct Server {
@@ -168,7 +168,7 @@ struct Server {
     pub compiled_lookup: CompiledFheProgram,
 
     /// The server's runtime
-    runtime: Runtime,
+    runtime: FheRuntime,
 }
 ```
 
@@ -178,8 +178,8 @@ Recall that the server is responsible for retrieving Alice's item from the datab
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, Params, PrivateKey,
-#     PublicKey, Runtime, FheRuntime
+#     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, FheRuntime,
+#     Params, PrivateKey, PublicKey,
 # };
 #
 # const DATABASE_SIZE: usize = 100;
@@ -190,11 +190,11 @@ Recall that the server is responsible for retrieving Alice's item from the datab
 # /// desired item's index and 0s elsewhere.
 # fn lookup(query: [Cipher<Signed>; DATABASE_SIZE], database: [Signed; DATABASE_SIZE]) -> Cipher<Signed> {
 #     let mut sum = query[0] * database[0];
-# 
+#
 #     for i in 1..DATABASE_SIZE {
 #         sum = sum + query[i] * database[i]
 #     }
-# 
+#
 #     sum
 # }
 #
@@ -213,7 +213,7 @@ impl Server {
             .fhe_program(lookup)
             .compile()?;
 
-        let runtime = Runtime::new_fhe(app.params())?;
+        let runtime = FheRuntime::new(app.params())?;
 
         Ok(Server {
             compiled_lookup: app.get_fhe_program(lookup).unwrap().clone(),
@@ -248,9 +248,9 @@ Using `run_query`, the server can return an (encrypted) response to Alice's quer
 
 The items in the database will be the integers from 400 to 499, stored in ascending order. Recall that `lookup` takes in two arguments---the encrypted query and the unencrypted database. Unfortunately, we'll need to do some type conversion for the `database` as Sunscreen's compiler needs the `Signed` type *not* `i64` for its programs.
 
-Additionally, to `run` FHE programs, we need to pass in arguments as a `vec`. Thus, we create a `vec` called `args` that contains our encrypted `query` and unencrypted `database` (which now has `Signed` entries rather than `i64` entries in it). 
+Additionally, to `run` FHE programs, we need to pass in arguments as a `vec`. Thus, we create a `vec` called `args` that contains our encrypted `query` and unencrypted `database` (which now has `Signed` entries rather than `i64` entries in it).
 
-Once all that's done, the server can `run` the FHE program by passing in the `compiled_lookup` program, the arguments to the program `args` (now contained in a `vec`), and Alice's `public_key`. 
+Once all that's done, the server can `run` the FHE program by passing in the `compiled_lookup` program, the arguments to the program `args` (now contained in a `vec`), and Alice's `public_key`.
 
 
 ### Retrieving the item privately
@@ -258,8 +258,8 @@ Once all that's done, the server can `run` the FHE program by passing in the `co
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, Params, PrivateKey,
-#     PublicKey, Runtime, FheRuntime
+#     Ciphertext, CompiledFheProgram, Compiler, Error, FheProgramInput, FheRuntime,
+#     Params, PrivateKey, PublicKey,
 # };
 #
 # const DATABASE_SIZE: usize = 100;
@@ -270,11 +270,11 @@ Once all that's done, the server can `run` the FHE program by passing in the `co
 # /// desired item's index and 0s elsewhere.
 # fn lookup(query: [Cipher<Signed>; DATABASE_SIZE], database: [Signed; DATABASE_SIZE]) -> Cipher<Signed> {
 #     let mut sum = query[0] * database[0];
-# 
+#
 #     for i in 1..DATABASE_SIZE {
 #         sum = sum + query[i] * database[i]
 #     }
-# 
+#
 #     sum
 # }
 #
@@ -293,7 +293,7 @@ Once all that's done, the server can `run` the FHE program by passing in the `co
 #
 # impl Alice {
 #     pub fn setup(params: &Params) -> Result<Alice, Error> {
-#         let runtime = Runtime::new_fhe(params)?;
+#         let runtime = FheRuntime::new(params)?;
 #
 #         let (public_key, private_key) = runtime.generate_keys()?;
 #
@@ -336,9 +336,9 @@ Once all that's done, the server can `run` the FHE program by passing in the `co
 #         let app = Compiler::new()
 #             .fhe_program(lookup)
 #             .compile()?;
-# 
-#         let runtime = Runtime::new_fhe(app.params())?;
-# 
+#
+#         let runtime = FheRuntime::new(app.params())?;
+#
 #         Ok(Server {
 #             compiled_lookup: app.get_fhe_program(lookup).unwrap().clone(),
 #             runtime,

--- a/sunscreen_docs/src/fhe_programs/runtime/decryption.md
+++ b/sunscreen_docs/src/fhe_programs/runtime/decryption.md
@@ -5,7 +5,7 @@ To decrypt, simply call `decrypt()` using your private key and the data you want
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Compiler, Runtime, PublicKey, PlainModulusConstraint
+#     Compiler, FheRuntime, PublicKey, PlainModulusConstraint
 # };
 #
 # #[fhe_program(scheme = "bfv")]
@@ -19,7 +19,7 @@ To decrypt, simply call `decrypt()` using your private key and the data you want
 #        .compile()
 #        .unwrap();
 #
-#    let runtime = Runtime::new_fhe(app.params()).unwrap();
+#    let runtime = FheRuntime::new(app.params()).unwrap();
 #    let (public_key, private_key) = runtime.generate_keys().unwrap();
 #
 #    let val = Signed::from(15);

--- a/sunscreen_docs/src/fhe_programs/runtime/encryption.md
+++ b/sunscreen_docs/src/fhe_programs/runtime/encryption.md
@@ -1,10 +1,10 @@
 # Encryption
-To encrypt data, simply call `encrypt()` on `Runtime`:
+To encrypt data, simply call `encrypt()` on `FheRuntime`:
 ```rust
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Compiler, Runtime, PublicKey
+#     Compiler, FheRuntime, PublicKey
 # };
 #
 # #[fhe_program(scheme = "bfv")]
@@ -17,7 +17,7 @@ To encrypt data, simply call `encrypt()` on `Runtime`:
 #        .compile()
 #        .unwrap();
 #
-#    let runtime = Runtime::new_fhe(app.params()).unwrap();
+#    let runtime = FheRuntime::new(app.params()).unwrap();
 #    let (public_key, private_key) = runtime.generate_keys().unwrap();
 #
     let val = Signed::from(15);

--- a/sunscreen_docs/src/fhe_programs/runtime/key_generation.md
+++ b/sunscreen_docs/src/fhe_programs/runtime/key_generation.md
@@ -5,7 +5,7 @@ Once you've created a runtime, generating keys is simple:
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Compiler, Runtime, PublicKey
+#     Compiler, FheRuntime, PublicKey
 # };
 #
 # #[fhe_program(scheme = "bfv")]
@@ -18,7 +18,7 @@ Once you've created a runtime, generating keys is simple:
 #        .compile()
 #        .unwrap();
 #
-#    let runtime = Runtime::new_fhe(app.params()).unwrap();
+#    let runtime = FheRuntime::new(app.params()).unwrap();
 #
     let (public_key, private_key) = runtime.generate_keys().unwrap();
 # }

--- a/sunscreen_docs/src/fhe_programs/runtime/running_fhe_programs.md
+++ b/sunscreen_docs/src/fhe_programs/runtime/running_fhe_programs.md
@@ -5,7 +5,7 @@ In our simple example, we called `runtime.run` to execute our FHE program
 ```rust
 # use sunscreen::{*, types::{{bfv::Signed}, Cipher}};
 #
-# fn main() { 
+# fn main() {
 #   #[fhe_program(scheme = "bfv")]
 #   fn multiply(a: Cipher<Signed>, b: Cipher<Signed>) -> Cipher<Signed> {
 #   a * b
@@ -17,7 +17,7 @@ In our simple example, we called `runtime.run` to execute our FHE program
 #       .compile()
 #       .unwrap();
 #
-#   let runtime = Runtime::new_fhe(app.params()).unwrap();
+#   let runtime = FheRuntime::new(app.params()).unwrap();
 #   let (public_key, _) = runtime.generate_keys().unwrap();
     let a_enc = runtime.encrypt(Signed::from(5), &public_key).unwrap();
     let b_enc = runtime.encrypt(Signed::from(15), &public_key).unwrap();
@@ -32,7 +32,7 @@ Let's break down the arguments to `runtime.run`:
 3. The final `public_key` argument is the public key used to generate the encrypted program inputs (i.e. `a_enc` and `b_enc`).
 
 ## FHE program inputs
-Rust requires collections be homogenous (i.e. each item is the same type). However, program arguments may not be always be of the same type! 
+Rust requires collections be homogenous (i.e. each item is the same type). However, program arguments may not be always be of the same type!
 
 Our `FheProgramInput` wrapper enum solves this problem; it wraps values so they can exist in a homogeneous collection. The run function's second argument is a `Vec<T>` where `T` readily converts into an `FheProgramInput` (i.e. `T impl` [`Into<FheProgramInput>`](https://doc.rust-lang.org/std/convert/trait.Into.html)[^1]). `Ciphertext` and all types under `sunscreen::bfv::types::*` do this.
 
@@ -54,7 +54,7 @@ If your FHE program only accepts ciphertexts (a common scenario), it's sufficien
 #         .compile()
 #         .unwrap();
 #
-#     let runtime = Runtime::new_fhe(app.params()).unwrap();
+#     let runtime = FheRuntime::new(app.params()).unwrap();
 #     let (public_key, _) = runtime.generate_keys().unwrap();
 
     let a_enc = runtime.encrypt(Signed::from(5), &public_key).unwrap();

--- a/sunscreen_docs/src/fhe_programs/runtime/runtime.md
+++ b/sunscreen_docs/src/fhe_programs/runtime/runtime.md
@@ -1,11 +1,11 @@
 # Runtime
-To create a runtime, you simply call `Runtime::new`, passing a `Params` object. You get a params object from compiling an FHE program as we did in our example.
+To create a runtime, you simply call `FheRuntime::new`, passing a `Params` object. You get a params object from compiling an FHE program as we did in our example.
 
 ```rust
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Compiler, Runtime, PublicKey
+#     Compiler, FheRuntime, PublicKey
 # };
 #
 # #[fhe_program(scheme = "bfv")]
@@ -18,7 +18,7 @@ To create a runtime, you simply call `Runtime::new`, passing a `Params` object. 
 #        .compile()
 #        .unwrap();
 #
-    let runtime = Runtime::new_fhe(app.params()).unwrap();
+    let runtime = FheRuntime::new(app.params()).unwrap();
 # }
 ```
 

--- a/sunscreen_docs/src/fhe_programs/runtime/serialization.md
+++ b/sunscreen_docs/src/fhe_programs/runtime/serialization.md
@@ -12,7 +12,7 @@ The process to serialize and deserialize any type is the same, but this example 
 # use sunscreen::{
 #     fhe_program,
 #     types::{bfv::Signed, Cipher},
-#     Compiler, Runtime, PublicKey, Ciphertext
+#     Compiler, FheRuntime, PublicKey, Ciphertext
 # };
 #
 # #[fhe_program(scheme = "bfv")]
@@ -25,7 +25,7 @@ The process to serialize and deserialize any type is the same, but this example 
 #        .compile()
 #        .unwrap();
 #
-#    let runtime = Runtime::new_fhe(app.params()).unwrap();
+#    let runtime = FheRuntime::new(app.params()).unwrap();
 #    let (public_key, _) = runtime.generate_keys().unwrap();
     let c = runtime
         .encrypt(Signed::from(20), &public_key)

--- a/sunscreen_runtime/src/runtime.rs
+++ b/sunscreen_runtime/src/runtime.rs
@@ -605,18 +605,51 @@ impl GenericRuntime<(), ()> {
  */
 pub type FheZkpRuntime<B> = GenericRuntime<FheZkp, B>;
 
+impl<B> FheZkpRuntime<B> {
+    /**
+     * Creates a new Runtime supporting both ZKP and FHE operations.
+     */
+    pub fn new(params: &Params, zkp_backend: &B) -> Result<Self>
+    where
+        B: ZkpBackend + Clone + 'static,
+    {
+        Runtime::new_fhe_zkp(params, zkp_backend)
+    }
+}
+
 /**
  * A runtime capable of only FHE operations.
  */
 pub type FheRuntime = GenericRuntime<Fhe, ()>;
+
+impl FheRuntime {
+    /**
+     * Create a new [`FheRuntime`].
+     */
+    pub fn new(params: &Params) -> Result<Self> {
+        Runtime::new_fhe(params)
+    }
+}
 
 /**
  * A runtime capable of only ZKP operations.
  */
 pub type ZkpRuntime<B> = GenericRuntime<Zkp, B>;
 
+impl<B> ZkpRuntime<B> {
+    /**
+     * Create a new [`ZkpRuntime`].
+     */
+    pub fn new(backend: &B) -> Result<Self>
+    where
+        B: ZkpBackend + Clone + 'static,
+    {
+        Runtime::new_zkp(backend)
+    }
+}
+
 /**
- * An type containing the `Runtime::new_*` constructor methods to create
+ * A type containing the `Runtime::new_*` constructor methods to create
  * the appropriate runtime:
  *
  * * [`Runtime::new_fhe`] constructs an [`FheRuntime`] capable of


### PR DESCRIPTION
When I was upgrading from `0.7.0` to `main`, I thought it was a bit awkward that users would import two types:
```rust
use sunscreen::{FheRuntime, Runtime};
let runtime: FheRuntime = Runtime::new_fhe(todo!())?;
```
This offers a more typical `new` api:
```rust
use sunscreen::FheRuntime;
let runtime = FheRuntime::new(todo!())?;
```

But I kept the `Runtime::{new_fhe, new_zkp, new_fhe_zkp}` functions around as well, just in case someone is in an odd situation where they want to make runtimes generically/dynamically. I could also update the examples and docs to use the new api, if desirable.