### PR TITLE
Build to_2s_complement by individual elements.

### DIFF
--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -845,7 +845,6 @@ impl LogProof {
      * This modifies bitvec in place.
      *
      */
-    #[inline]
     fn to_2s_complement_single<Q, const N: usize>(
         value: &Fp<MontBackend<Q, N>, N>,
         log_b: u64,


### PR DESCRIPTION
This change is a no-op on the result; it is a precursor to having bounds that can vary on each element in the input array.