### PR TITLE
Misc typos / Fix lib exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2619,7 +2619,6 @@ name = "sudoku_zkp"
 version = "0.1.0"
 dependencies = [
  "sunscreen",
- "sunscreen_zkp_backend",
 ]
 
 [[package]]

--- a/examples/sudoku_zkp/Cargo.toml
+++ b/examples/sudoku_zkp/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sunscreen = { path = "../../sunscreen" }
-sunscreen_zkp_backend = { path = "../../sunscreen_zkp_backend" }
+sunscreen = { path = "../../sunscreen", features = ["bulletproofs"] }
+

--- a/examples/sudoku_zkp/src/main.rs
+++ b/examples/sudoku_zkp/src/main.rs
@@ -1,7 +1,7 @@
 use sunscreen::{
-    types::zkp::NativeField, zkp_program, BackendField, Compiler, Runtime, ZkpProgramInput,
+    types::zkp::NativeField, zkp_program, BackendField, BulletproofsBackend, Compiler, Runtime,
+    ZkpBackend, ZkpProgramInput,
 };
-use sunscreen_zkp_backend::{bulletproofs::BulletproofsBackend, ZkpBackend};
 
 type BPField = NativeField<<BulletproofsBackend as ZkpBackend>::Field>;
 

--- a/sunscreen/src/fhe/mod.rs
+++ b/sunscreen/src/fhe/mod.rs
@@ -157,7 +157,7 @@ pub type FheFrontendCompilation = CompilationResult<FheOperation>;
 
 thread_local! {
     /**
-     * Contains the graph of a ZKP program during compilation. An
+     * Contains the graph of an FHE program during compilation. An
      * implementation detail and not for public consumption.
      */
     pub static CURRENT_FHE_CTX: RefCell<Option<&'static mut FheContext>> = RefCell::new(None);

--- a/sunscreen/src/lib.rs
+++ b/sunscreen/src/lib.rs
@@ -85,6 +85,8 @@ pub use sunscreen_runtime::{
     InnerPlaintext, Params, Plaintext, PrivateKey, PublicKey, RequiredKeys, Runtime, WithContext,
     ZkpProgramInput, ZkpRuntime,
 };
+#[cfg(feature = "bulletproofs")]
+pub use sunscreen_zkp_backend::bulletproofs::{BulletproofsBackend, BulletproofsR1CSProof};
 pub use sunscreen_zkp_backend::{BackendField, Error as ZkpError, Result as ZkpResult, ZkpBackend};
 pub use zkp::ZkpProgramFn;
 pub use zkp::{

--- a/sunscreen_compiler_macros/src/zkp_program.rs
+++ b/sunscreen_compiler_macros/src/zkp_program.rs
@@ -35,7 +35,10 @@ pub fn zkp_program_impl(
 
 fn get_generic_arg(generics: &Generics) -> Result<(Ident, Path)> {
     if generics.type_params().count() != 1 {
-        return Err(Error::compile_error(generics.span(), "ZKP programs must take 1 generic argument with bound sunscreen::BackendField.sunscreen::BackendField"));
+        return Err(Error::compile_error(
+            generics.span(),
+            "ZKP programs must take 1 generic argument with bound sunscreen::BackendField",
+        ));
     }
 
     if generics.lifetimes().count() > 0 {

--- a/sunscreen_runtime/src/metadata.rs
+++ b/sunscreen_runtime/src/metadata.rs
@@ -8,7 +8,8 @@ use sunscreen_fhe_program::{FheProgram, SchemeType};
 use crate::{Error, Result};
 
 /**
- * Indicates the type signatures of an Fhe Program. Serves as a piece of the [`FheProgramMetadata`].
+ * Indicates the type signature of an FHE or ZKP program. Serves as a piece of the
+ * [`FheProgramMetadata`] or [`ZkpProgramFn`] respectively.
  *
  * # Remarks
  * This type is serializable and FHE program implementors can give this object
@@ -18,28 +19,29 @@ use crate::{Error, Result};
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CallSignature {
     /**
-     * The type of each argument in the FHE program.
+     * The type of each argument in the program.
      *
      * # Remarks
-     * The ith argument to the FHE program occupies the ith argument of the vector.
-     * The length of this vector equals the number of arguments to the FHE program.
+     * The ith argument to the program occupies the ith element of the vector.
+     * The length of this vector equals the number of arguments to the program.
      */
     pub arguments: Vec<Type>,
 
     /**
-     * The type of the single return value of the FHE program if the return type is
-     * not a type. If the return type of the FHE program is a tuple, then this contains
+     * The type of the single return value of the program if the return type is
+     * not a tuple. If the return type of the program is a tuple, then this contains
      * each type in the tuple.
-     *
-     * # Remarks
-     * The ith argument to the FHE program occupies the ith argument of the vector.
-     * The length of this vector equals the number of arguments to the FHE program.
      */
     pub returns: Vec<Type>,
 
     /**
-     * The number of ciphertexts that compose the nth return value.
+     * The number of ciphertexts that compose the corresponding return value.
+     *
+     * # Remarks
+     * The number of ciphertexts composing the ith return value of the program occupies the ith
+     * element of the vector. The length of this vector equals the length of the returns.
      */
+    // TODO This field is specific to FHE; should we segment the types here? CallSignature<Fhe|Zkp> ?
     pub num_ciphertexts: Vec<usize>,
 }
 

--- a/sunscreen_runtime/src/metadata.rs
+++ b/sunscreen_runtime/src/metadata.rs
@@ -8,8 +8,7 @@ use sunscreen_fhe_program::{FheProgram, SchemeType};
 use crate::{Error, Result};
 
 /**
- * Indicates the type signature of an FHE or ZKP program. Serves as a piece of the
- * [`FheProgramMetadata`] or [`ZkpProgramFn`] respectively.
+ * Indicates the type signature of an FHE or ZKP program.
  *
  * # Remarks
  * This type is serializable and FHE program implementors can give this object

--- a/sunscreen_zkp_backend/src/bulletproofs.rs
+++ b/sunscreen_zkp_backend/src/bulletproofs.rs
@@ -99,7 +99,7 @@ impl Neg for Node {
 /**
  * A Bulletproofs R1CS circuit.
  */
-pub struct BulletproofsCircuit {
+struct BulletproofsCircuit {
     nodes: Vec<Option<Node>>,
 }
 


### PR DESCRIPTION
- Drive-by fixes to rust docs
- I missed this in Bryan's initial sudoku PR, but he had to specify a dependency on the local `sunscreen_zkp_backend` crate; changes here allow users to import those types from the main `sunscreen` lib.