### PR TITLE
Add CSV stdout for logproof bench

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1570,6 +1570,7 @@ dependencies = [
  "criterion 0.4.0",
  "digest 0.10.7",
  "merlin",
+ "once_cell",
  "rand",
  "rayon",
  "serde",
@@ -1894,9 +1895,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "oorandom"

--- a/logproof/Cargo.toml
+++ b/logproof/Cargo.toml
@@ -21,6 +21,7 @@ sunscreen_math = { path = "../sunscreen_math" }
 [dev-dependencies]
 bincode = "1.3.3"
 criterion = "0.4.0"
+once_cell = "1.18.0"
 
 [features]
 default = []

--- a/logproof/benches/linear_relation.rs
+++ b/logproof/benches/linear_relation.rs
@@ -1,4 +1,5 @@
-use std::time::Instant;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
 
 use ark_ff::{FftField, Field};
 use ark_poly::univariate::DensePolynomial;
@@ -11,8 +12,36 @@ use logproof::{
     InnerProductVerifierKnowledge, LogProof, LogProofGenerators, LogProofProverKnowledge,
 };
 use merlin::Transcript;
+use once_cell::sync::Lazy;
+
+// Change these two lines to change how much time is spent sleeping between
+// benchmarks to cool down the machine.
+const THERMAL_THROTTLE: bool = true;
+const THERMAL_THROTTLE_TIME: u64 = 30;
 
 type MatrixPoly<Q> = Matrix<DensePolynomial<Q>>;
+
+static RESULTS: Lazy<Mutex<String>> = Lazy::new(|| {
+    Mutex::new(
+        "Degree, Ciphertexts, Setup Time [s], Prover Time [s], Verifier Time [s], Prover Size [B]\n"
+            .to_string(),
+    )
+});
+
+fn append_result(
+    degree: u64,
+    ciphertexts: usize,
+    setup_time: f64,
+    prover_time: f64,
+    verifier_time: f64,
+    prover_size: usize,
+) {
+    let new_row = format!(
+        "{degree}, {ciphertexts}, {setup_time}, {prover_time}, {verifier_time}, {prover_size}\n"
+    );
+    let mut r = RESULTS.lock().unwrap();
+    (*r).push_str(&new_row);
+}
 
 fn f<F: Field>(degree: usize) -> DensePolynomial<F> {
     let mut coeffs = Vec::with_capacity(degree + 1);
@@ -41,10 +70,12 @@ where
     // Really wish we had `generic_const_exprs` in stable...
     assert_eq!(2 * CT, CT2);
 
-    // Uncomment below 2 lines if you're on a machine that has cooling issues and
-    // thermally throttles CPU e.g. M1 Macbook Air.
-    //println!("Sleeping for 120s to prevent thermal throttling of successive benchmarks...");
-    //std::thread::sleep(Duration::from_secs(120));
+    if THERMAL_THROTTLE {
+        println!(
+        "Sleeping for {THERMAL_THROTTLE_TIME} seconds to prevent thermal throttling of successive benchmarks..."
+    );
+        std::thread::sleep(Duration::from_secs(THERMAL_THROTTLE_TIME));
+    }
 
     // Secret key
     // a = random in q
@@ -94,24 +125,34 @@ where
     let now = Instant::now();
     let gens = LogProofGenerators::new(pk.vk.l() as usize);
     let u = InnerProductVerifierKnowledge::get_u();
-    println!("Setup time {}s", now.elapsed().as_secs_f64());
+    let setup_time = now.elapsed().as_secs_f64();
 
     let now = Instant::now();
-
     let proof = LogProof::create(&mut transcript, &pk, &gens.g, &gens.h, &u);
-
-    println!("Prover time {}s", now.elapsed().as_secs_f64());
-    println!("Proof size {}B", bincode::serialize(&proof).unwrap().len());
+    let prover_time = now.elapsed().as_secs_f64();
+    let prover_size = bincode::serialize(&proof).unwrap().len();
 
     let mut transcript = Transcript::new(b"test");
 
     let now = Instant::now();
-
     proof
         .verify(&mut transcript, &pk.vk, &gens.g, &gens.h, &u)
         .unwrap();
+    let verifier_time = now.elapsed().as_secs_f64();
 
-    println!("Verifier time {}s", now.elapsed().as_secs_f64());
+    println!("Setup time: {setup_time}");
+    println!("Prover time: {prover_time}");
+    println!("Verifier time: {verifier_time}");
+    println!("Prover size: {prover_size}");
+
+    append_result(
+        POLY_DEGREE,
+        CT,
+        setup_time,
+        prover_time,
+        verifier_time,
+        prover_size,
+    );
 }
 
 fn params_1024_3ct(_: &mut Criterion) {
@@ -159,6 +200,11 @@ fn params_4096_1ct(_: &mut Criterion) {
     bfv_benchmark::<FqSeal128_4096, 4096, 1, 2>();
 }
 
+fn print_results(_: &mut Criterion) {
+    println!("Printing out results as a csv table\n");
+    println!("{}", *RESULTS.lock().unwrap());
+}
+
 criterion_group!(
     benches,
     params_1024_1ct,
@@ -169,7 +215,8 @@ criterion_group!(
     params_2048_3ct,
     params_4096_1ct,
     params_4096_2ct,
-    params_4096_3ct
+    params_4096_3ct,
+    print_results
 );
 
 criterion_main!(benches);


### PR DESCRIPTION
Makes a few small improvements to logproof benchmarks to make them easier to run:

1. Outputs the results at the end as a csv formatted table for easier plotting in other programs.
2. Makes the optional thermal throttle a boolean instead of commenting out code. This change was because commenting out the code also required adding an import (`Duration`), so this is slightly easier to use.