### PR TITLE
Fix assert_poly_expansion for k > 1

### DIFF
--- a/logproof/src/assertions.rs
+++ b/logproof/src/assertions.rs
@@ -132,13 +132,6 @@ pub mod linear_relation {
         assert_eq!(lhs, t.evaluate(&alpha));
     }
 
-    fn replicate_as_matrix<T>(v: Vec<T>, k: usize) -> Matrix<T>
-    where
-        T: Zero + Copy,
-    {
-        Matrix::from((vec![v; k]).into_iter().flatten().collect::<Vec<T>>())
-    }
-
     /**
      * Asserts the first identity after equation 18 in the short discrete
      * log proof paper. I.e., multiply both sides by gamma transpose and

--- a/logproof/src/assertions.rs
+++ b/logproof/src/assertions.rs
@@ -16,8 +16,6 @@ use crate::{
 
 #[allow(unused)]
 pub mod linear_relation {
-    use std::ops::Mul;
-
     use super::*;
 
     /**

--- a/logproof/src/assertions.rs
+++ b/logproof/src/assertions.rs
@@ -7,7 +7,8 @@ use crate::{
     crypto::CryptoHash,
     fields::{FieldFrom, FieldInto, FpRistretto},
     linear_algebra::{
-        HadamardProduct, Identity, InnerProduct, Matrix, PolynomialMatrix, ScalarMul,
+        kronecker_product, HadamardProduct, Identity, InnerProduct, Matrix, PolynomialMatrix,
+        ScalarMul,
     },
     linear_relation::ProverKnowledge,
     math::{FieldModulus, ModSwitch, One, Powers, Tensor, TwosComplementCoeffs, Zero},
@@ -15,6 +16,8 @@ use crate::{
 
 #[allow(unused)]
 pub mod linear_relation {
+    use std::ops::Mul;
+
     use super::*;
 
     /**
@@ -119,14 +122,21 @@ pub mod linear_relation {
 
         let i = Matrix::<FpRistretto>::identity(k);
 
-        let a_eval = a.evaluate(&alpha);
+        let a_eval: Matrix<FpRistretto> = a.evaluate(&alpha);
         let f_eval = f.evaluate(&alpha);
 
-        let lhs = a_eval * s * Matrix::from((&i).tensor(alpha_d))
-            + r_1.scalar_mul(q) * Matrix::from((&i).tensor(alpha_2d_min_1))
-            + r_2.scalar_mul(f_eval) * Matrix::from((&i).tensor(alpha_d_min_1));
+        let lhs = a_eval * s * kronecker_product(&i, &Matrix::from(alpha_d))
+            + r_1.scalar_mul(q) * kronecker_product(&i, &Matrix::from(alpha_2d_min_1))
+            + r_2.scalar_mul(f_eval) * kronecker_product(&i, &Matrix::from(alpha_d_min_1));
 
         assert_eq!(lhs, t.evaluate(&alpha));
+    }
+
+    fn replicate_as_matrix<T>(v: Vec<T>, k: usize) -> Matrix<T>
+    where
+        T: Zero + Copy,
+    {
+        Matrix::from((vec![v; k]).into_iter().flatten().collect::<Vec<T>>())
     }
 
     /**

--- a/logproof/src/linear_algebra.rs
+++ b/logproof/src/linear_algebra.rs
@@ -1153,7 +1153,7 @@ mod tests {
 
         let b_values = [[1], [2]];
 
-        let c_values = [
+        let a_kron_b_values = [
             [1, 2, 3],
             [2, 4, 6],
             [4, 5, 6],
@@ -1162,12 +1162,25 @@ mod tests {
             [14, 16, 18],
         ];
 
-        let c_expected = Matrix::from(c_values.map(|row| row.map(Fp::from)));
+        let b_kron_a_values = [
+            [1, 2, 3],
+            [4, 5, 6],
+            [7, 8, 9],
+            [2, 4, 6],
+            [8, 10, 12],
+            [14, 16, 18],
+        ];
 
         let a = Matrix::from(a_values.map(|row| row.map(Fp::from)));
         let b = Matrix::from(b_values.map(|row| row.map(Fp::from)));
-        let c = kronecker_product(&a, &b);
 
-        assert_eq!(c, c_expected);
+        let a_kron_b_expected = Matrix::from(a_kron_b_values.map(|row| row.map(Fp::from)));
+        let b_kron_a_expected = Matrix::from(b_kron_a_values.map(|row| row.map(Fp::from)));
+
+        let a_kron_b = kronecker_product(&a, &b);
+        let b_kron_a = kronecker_product(&b, &a);
+
+        assert_eq!(a_kron_b, a_kron_b_expected);
+        assert_eq!(b_kron_a, b_kron_a_expected);
     }
 }

--- a/logproof/src/linear_algebra.rs
+++ b/logproof/src/linear_algebra.rs
@@ -317,6 +317,26 @@ where
     }
 }
 
+impl<F> From<Vec<Vec<F>>> for Matrix<F>
+where
+    F: Zero + Clone,
+{
+    fn from(vec_matrix: Vec<Vec<F>>) -> Self {
+        let rows = vec_matrix.len();
+        assert!(rows != 0);
+
+        let cols = vec_matrix[0].len();
+
+        for row in &vec_matrix {
+            assert_eq!(cols, row.len());
+        }
+
+        let data: Vec<F> = vec_matrix.into_iter().flatten().collect();
+
+        Self { rows, cols, data }
+    }
+}
+
 impl<F> From<&[F]> for Matrix<F>
 where
     F: Zero + Clone,
@@ -613,6 +633,29 @@ where
             .collect::<Vec<_>>()
             .concat()
     }
+}
+
+/**
+ * Computes the kronkecker product between two matrices. This is also the
+ * tensor product between two matrices.
+ */
+pub fn kronecker_product<F>(m: &Matrix<F>, n: &Matrix<F>) -> Matrix<F>
+where
+    F: Zero + Copy + Mul<F, Output = F>,
+{
+    let mut result = Matrix::zero(m.rows * n.rows, m.cols * n.cols);
+
+    for i in 0..m.rows {
+        for k in 0..n.rows {
+            for j in 0..m.cols {
+                for l in 0..n.cols {
+                    result[(i * n.rows + k, j * n.cols + l)] = m[(i, j)] * n[(k, l)];
+                }
+            }
+        }
+    }
+
+    result
 }
 
 impl<T, U> FieldFrom<Matrix<U>> for Matrix<T>
@@ -1100,5 +1143,31 @@ mod tests {
         let b = vec![Fp::from(1), Fp::from(2), Fp::from(3), Fp::from(4)];
 
         assert_eq!(a.as_bitslice().inner_product(b.as_slice()), Fp::from(6));
+    }
+
+    #[test]
+    fn test_kronecker_product() {
+        type Fp = FpRistretto;
+
+        let a_values = [[1, 2, 3], [4, 5, 6], [7, 8, 9]];
+
+        let b_values = [[1], [2]];
+
+        let c_values = [
+            [1, 2, 3],
+            [2, 4, 6],
+            [4, 5, 6],
+            [8, 10, 12],
+            [7, 8, 9],
+            [14, 16, 18],
+        ];
+
+        let c_expected = Matrix::from(c_values.map(|row| row.map(Fp::from)));
+
+        let a = Matrix::from(a_values.map(|row| row.map(Fp::from)));
+        let b = Matrix::from(b_values.map(|row| row.map(Fp::from)));
+        let c = kronecker_product(&a, &b);
+
+        assert_eq!(c, c_expected);
     }
 }

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -348,7 +348,7 @@ impl LogProof {
 
         if cfg!(debug_assertions) {
             linear_relation::assert_eval(pk, &r_1, &r_2, &alpha);
-            // Problematic
+
             linear_relation::assert_poly_expansion(
                 pk,
                 &s_serialized,

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -348,6 +348,7 @@ impl LogProof {
 
         if cfg!(debug_assertions) {
             linear_relation::assert_eval(pk, &r_1, &r_2, &alpha);
+            // Problematic
             linear_relation::assert_poly_expansion(
                 pk,
                 &s_serialized,
@@ -355,6 +356,7 @@ impl LogProof {
                 &r_2_serialized,
                 &alpha,
             );
+
             linear_relation::assert_scaled_poly_expansion(
                 pk,
                 &s_serialized,
@@ -364,6 +366,7 @@ impl LogProof {
                 &beta,
                 &gamma,
             );
+
             linear_relation::assert_inner_product_form(
                 pk,
                 &s_serialized,
@@ -953,7 +956,9 @@ mod test {
 
     use super::*;
 
-    fn test_lattice<Q>() -> (
+    fn test_lattice<Q>(
+        k: usize,
+    ) -> (
         MatrixPoly<Q>,
         MatrixPoly<Q>,
         MatrixPoly<Q>,
@@ -975,11 +980,22 @@ mod test {
             ],
         ]);
 
-        let s = MatrixPoly::from([
-            [make_poly::<Q>(&[1, 2, 3, 4, 5, 6, 7, 8])],
-            [make_poly::<Q>(&[1, 0, 1, 0, 1, 0, 1])],
-            [make_poly::<Q>(&[0, 1, 0, 1, 1, 0, 1])],
-        ]);
+        let s_coeff = vec![
+            vec![vec![1u64, 2, 3, 4, 5, 6, 7, 8]; k],
+            vec![vec![1, 0, 1, 0, 1, 0, 1]; k],
+            vec![vec![0, 1, 0, 1, 1, 0, 1]; k],
+        ];
+
+        let s_poly = s_coeff
+            .iter()
+            .map(|x| {
+                x.iter()
+                    .map(|y| make_poly::<Q>(y))
+                    .collect::<Vec<DensePolynomial<Q>>>()
+            })
+            .collect::<Vec<Vec<DensePolynomial<Q>>>>();
+
+        let s = MatrixPoly::from(s_poly);
 
         // x^8 + 1
         let f = make_poly::<Q>(&[1, 0, 0, 0, 0, 0, 0, 0, 1]);
@@ -995,7 +1011,7 @@ mod test {
     fn can_compute_residues() {
         type Q = FqSeal128_8192;
 
-        let (a, s, t_mod_f, f) = test_lattice::<Q>();
+        let (a, s, t_mod_f, f) = test_lattice::<Q>(1);
 
         let (r_2, r_1) = LogProof::compute_factors(&a, &s, &t_mod_f, &f);
 
@@ -1125,11 +1141,10 @@ mod test {
         assert_eq!(i + i, i);
     }
 
-    #[test]
-    fn transcripts_match() {
+    fn transcripts_match(k: usize) {
         type Fq = FqSeal128_8192;
 
-        let (a, s, t, f) = test_lattice::<Fq>();
+        let (a, s, t, f) = test_lattice::<Fq>(k);
 
         let pk = ProverKnowledge::new(&a, &s, &t, 16, &f);
 
@@ -1149,5 +1164,15 @@ mod test {
         let r = verify_transcript.challenge_scalar(b"verify");
 
         assert_eq!(l, r);
+    }
+
+    #[test]
+    fn transcripts_match_k_1() {
+        transcripts_match(1);
+    }
+
+    #[test]
+    fn transcripts_match_k_2() {
+        transcripts_match(2);
     }
 }


### PR DESCRIPTION
The polynomial expansion was using a flattened tensor product when a normal kronecker product should have been used. This fixes that error.

As a consequence, it is now also possible to create a matrix from a vector of vectors. This was implemented to make it easier to create the test cases for k > 1.