### PR TITLE
Switch SEAL submodule to sunscreen org

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "seal_fhe/SEAL"]
 	path = seal_fhe/SEAL
-	url = https://github.com/rickwebiii/SEAL.git
-	branch = wasm
-  fetchRecurseSubmodules = true
+	url = https://github.com/Sunscreen-tech/SEAL.git
+	branch = sunscreen
+        fetchRecurseSubmodules = true
 [submodule "emsdk/emsdk"]
 	path = emsdk/emsdk
 	url = https://github.com/emscripten-core/emsdk.git


### PR DESCRIPTION
Previously the `SEAL` submodule was tried to Rick's copy, but this meant that only Rick could push updates to SEAL. I forked the SEAL repo to the Sunscreen-tech organization and pulled in Rick's commits (at the correct branch point) so that SEAL can be more easily modified by the team.