### PR TITLE
Properly factor inserting literal plaintexts

### DIFF
--- a/sunscreen/src/types/bfv/batched.rs
+++ b/sunscreen/src/types/bfv/batched.rs
@@ -576,10 +576,9 @@ impl<const LANES: usize> GraphCipherConstMul for Batched<LANES> {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: Self::Right,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let l = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
-            let l = ctx.add_plaintext_literal(b.inner);
-            let n = ctx.add_multiplication_plaintext(a.ids[0], l);
+            let n = ctx.add_multiplication_plaintext(a.ids[0], l.ids[0]);
 
             FheProgramNode::new(&[n])
         })

--- a/sunscreen/src/types/bfv/fractional.rs
+++ b/sunscreen/src/types/bfv/fractional.rs
@@ -258,12 +258,9 @@ impl<const INT_BITS: usize> GraphCipherConstAdd for Fractional<INT_BITS> {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: Self::Right,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
-
-            let lit = ctx.add_plaintext_literal(b.inner);
-            let n = ctx.add_addition_plaintext(a.ids[0], lit);
-
+            let n = ctx.add_addition_plaintext(a.ids[0], lit.ids[0]);
             FheProgramNode::new(&[n])
         })
     }
@@ -326,12 +323,9 @@ impl<const INT_BITS: usize> GraphCipherConstSub for Fractional<INT_BITS> {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: Self::Right,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
-
-            let lit = ctx.add_plaintext_literal(b.inner);
-            let n = ctx.add_subtraction_plaintext(a.ids[0], lit);
-
+            let n = ctx.add_subtraction_plaintext(a.ids[0], lit.ids[0]);
             FheProgramNode::new(&[n])
         })
     }
@@ -345,11 +339,9 @@ impl<const INT_BITS: usize> GraphConstCipherSub for Fractional<INT_BITS> {
         a: Self::Left,
         b: FheProgramNode<Cipher<Self::Right>>,
     ) -> FheProgramNode<Cipher<Self::Right>> {
+        let lit = Self::graph_cipher_insert(a);
         with_fhe_ctx(|ctx| {
-            let a = Self::from(a).try_into_plaintext(&ctx.data).unwrap();
-
-            let lit = ctx.add_plaintext_literal(a.inner);
-            let n = ctx.add_subtraction_plaintext(b.ids[0], lit);
+            let n = ctx.add_subtraction_plaintext(b.ids[0], lit.ids[0]);
             let n = ctx.add_negate(n);
 
             FheProgramNode::new(&[n])
@@ -397,12 +389,9 @@ impl<const INT_BITS: usize> GraphCipherConstMul for Fractional<INT_BITS> {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: Self::Right,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
-            let lit = ctx.add_plaintext_literal(b.inner);
-
-            let n = ctx.add_multiplication_plaintext(a.ids[0], lit);
-
+            let n = ctx.add_multiplication_plaintext(a.ids[0], lit.ids[0]);
             FheProgramNode::new(&[n])
         })
     }
@@ -416,16 +405,9 @@ impl<const INT_BITS: usize> GraphCipherConstDiv for Fractional<INT_BITS> {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: f64,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(1. / b);
         with_fhe_ctx(|ctx| {
-            let b = Self::try_from(1. / b)
-                .unwrap()
-                .try_into_plaintext(&ctx.data)
-                .unwrap();
-
-            let lit = ctx.add_plaintext_literal(b.inner);
-
-            let n = ctx.add_multiplication_plaintext(a.ids[0], lit);
-
+            let n = ctx.add_multiplication_plaintext(a.ids[0], lit.ids[0]);
             FheProgramNode::new(&[n])
         })
     }

--- a/sunscreen/src/types/bfv/rational.rs
+++ b/sunscreen/src/types/bfv/rational.rs
@@ -341,21 +341,14 @@ impl GraphCipherConstAdd for Rational {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: Self::Right,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::try_from(b).unwrap();
-
-            let b_num =
-                ctx.add_plaintext_literal(b.num.try_into_plaintext(&ctx.data).unwrap().inner);
-
-            let b_den =
-                ctx.add_plaintext_literal(b.den.try_into_plaintext(&ctx.data).unwrap().inner);
-
             // Scale each numinator by the other's denominator.
-            let num_a_2 = ctx.add_multiplication_plaintext(a.ids[0], b_den);
-            let num_b_2 = ctx.add_multiplication_plaintext(a.ids[1], b_num);
+            let num_a_2 = ctx.add_multiplication_plaintext(a.ids[0], lit.ids[1]);
+            let num_b_2 = ctx.add_multiplication_plaintext(a.ids[1], lit.ids[0]);
 
             // Get denominators to have the same scale
-            let den_2 = ctx.add_multiplication_plaintext(a.ids[1], b_den);
+            let den_2 = ctx.add_multiplication_plaintext(a.ids[1], lit.ids[1]);
 
             let ids = [ctx.add_addition(num_a_2, num_b_2), den_2];
 
@@ -441,20 +434,14 @@ impl GraphCipherConstSub for Rational {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: Self::Right,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::try_from(b).unwrap();
-
-            let b_num =
-                ctx.add_plaintext_literal(b.num.try_into_plaintext(&ctx.data).unwrap().inner);
-            let b_den =
-                ctx.add_plaintext_literal(b.den.try_into_plaintext(&ctx.data).unwrap().inner);
-
             // Scale each numinator by the other's denominator.
-            let num_a_2 = ctx.add_multiplication_plaintext(a.ids[0], b_den);
-            let num_b_2 = ctx.add_multiplication_plaintext(a.ids[1], b_num);
+            let num_a_2 = ctx.add_multiplication_plaintext(a.ids[0], lit.ids[1]);
+            let num_b_2 = ctx.add_multiplication_plaintext(a.ids[1], lit.ids[0]);
 
             // Get denominators to have the same scale
-            let den_2 = ctx.add_multiplication_plaintext(a.ids[1], b_den);
+            let den_2 = ctx.add_multiplication_plaintext(a.ids[1], lit.ids[1]);
 
             let ids = [ctx.add_subtraction(num_a_2, num_b_2), den_2];
 
@@ -471,20 +458,14 @@ impl GraphConstCipherSub for Rational {
         a: Self::Left,
         b: FheProgramNode<Cipher<Self::Right>>,
     ) -> FheProgramNode<Cipher<Self::Right>> {
+        let lit = Self::graph_cipher_insert(a);
         with_fhe_ctx(|ctx| {
-            let a = Self::try_from(a).unwrap();
-
-            let a_num =
-                ctx.add_plaintext_literal(a.num.try_into_plaintext(&ctx.data).unwrap().inner);
-            let a_den =
-                ctx.add_plaintext_literal(a.den.try_into_plaintext(&ctx.data).unwrap().inner);
-
             // Scale each numinator by the other's denominator.
-            let num_b_2 = ctx.add_multiplication_plaintext(b.ids[0], a_den);
-            let num_a_2 = ctx.add_multiplication_plaintext(b.ids[1], a_num);
+            let num_b_2 = ctx.add_multiplication_plaintext(b.ids[0], lit.ids[1]);
+            let num_a_2 = ctx.add_multiplication_plaintext(b.ids[1], lit.ids[0]);
 
             // Get denominators to have the same scale
-            let den_2 = ctx.add_multiplication_plaintext(b.ids[1], a_den);
+            let den_2 = ctx.add_multiplication_plaintext(b.ids[1], lit.ids[1]);
 
             let ids = [ctx.add_subtraction(num_a_2, num_b_2), den_2];
 
@@ -502,7 +483,6 @@ impl GraphCipherMul for Rational {
         b: FheProgramNode<Cipher<Self::Right>>,
     ) -> FheProgramNode<Cipher<Self::Left>> {
         with_fhe_ctx(|ctx| {
-            // Scale each numinator by the other's denominator.
             let mul_num = ctx.add_multiplication(a.ids[0], b.ids[0]);
             let mul_den = ctx.add_multiplication(a.ids[1], b.ids[1]);
 
@@ -522,7 +502,6 @@ impl GraphCipherPlainMul for Rational {
         b: FheProgramNode<Self::Right>,
     ) -> FheProgramNode<Cipher<Self::Left>> {
         with_fhe_ctx(|ctx| {
-            // Scale each numinator by the other's denominator.
             let mul_num = ctx.add_multiplication_plaintext(a.ids[0], b.ids[0]);
             let mul_den = ctx.add_multiplication_plaintext(a.ids[1], b.ids[1]);
 
@@ -541,17 +520,10 @@ impl GraphCipherConstMul for Rational {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: Self::Right,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::try_from(b).unwrap();
-
-            let num_b =
-                ctx.add_plaintext_literal(b.num.try_into_plaintext(&ctx.data).unwrap().inner);
-            let den_b =
-                ctx.add_plaintext_literal(b.den.try_into_plaintext(&ctx.data).unwrap().inner);
-
-            // Scale each numinator by the other's denominator.
-            let mul_num = ctx.add_multiplication_plaintext(a.ids[0], num_b);
-            let mul_den = ctx.add_multiplication_plaintext(a.ids[1], den_b);
+            let mul_num = ctx.add_multiplication_plaintext(a.ids[0], lit.ids[0]);
+            let mul_den = ctx.add_multiplication_plaintext(a.ids[1], lit.ids[1]);
 
             let ids = [mul_num, mul_den];
 
@@ -569,7 +541,6 @@ impl GraphCipherDiv for Rational {
         b: FheProgramNode<Cipher<Self::Right>>,
     ) -> FheProgramNode<Cipher<Self::Left>> {
         with_fhe_ctx(|ctx| {
-            // Scale each numinator by the other's denominator.
             let mul_num = ctx.add_multiplication(a.ids[0], b.ids[1]);
             let mul_den = ctx.add_multiplication(a.ids[1], b.ids[0]);
 
@@ -589,7 +560,6 @@ impl GraphCipherPlainDiv for Rational {
         b: FheProgramNode<Self::Right>,
     ) -> FheProgramNode<Cipher<Self::Left>> {
         with_fhe_ctx(|ctx| {
-            // Scale each numinator by the other's denominator.
             let mul_num = ctx.add_multiplication_plaintext(a.ids[0], b.ids[1]);
             let mul_den = ctx.add_multiplication_plaintext(a.ids[1], b.ids[0]);
 
@@ -609,7 +579,6 @@ impl GraphPlainCipherDiv for Rational {
         b: FheProgramNode<Cipher<Self::Right>>,
     ) -> FheProgramNode<Cipher<Self::Left>> {
         with_fhe_ctx(|ctx| {
-            // Scale each numinator by the other's denominator.
             let mul_num = ctx.add_multiplication_plaintext(b.ids[1], a.ids[0]);
             let mul_den = ctx.add_multiplication_plaintext(b.ids[0], a.ids[1]);
 
@@ -628,17 +597,10 @@ impl GraphCipherConstDiv for Rational {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: Self::Right,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::try_from(b).unwrap();
-
-            let num_b =
-                ctx.add_plaintext_literal(b.num.try_into_plaintext(&ctx.data).unwrap().inner);
-            let den_b =
-                ctx.add_plaintext_literal(b.den.try_into_plaintext(&ctx.data).unwrap().inner);
-
-            // Scale each numinator by the other's denominator.
-            let mul_num = ctx.add_multiplication_plaintext(a.ids[0], den_b);
-            let mul_den = ctx.add_multiplication_plaintext(a.ids[1], num_b);
+            let mul_num = ctx.add_multiplication_plaintext(a.ids[0], lit.ids[1]);
+            let mul_den = ctx.add_multiplication_plaintext(a.ids[1], lit.ids[0]);
 
             let ids = [mul_num, mul_den];
 
@@ -655,17 +617,10 @@ impl GraphConstCipherDiv for Rational {
         a: Self::Left,
         b: FheProgramNode<Cipher<Self::Right>>,
     ) -> FheProgramNode<Cipher<Self::Right>> {
+        let lit = Self::graph_cipher_insert(a);
         with_fhe_ctx(|ctx| {
-            let a = Self::try_from(a).unwrap();
-
-            let num_a =
-                ctx.add_plaintext_literal(a.num.try_into_plaintext(&ctx.data).unwrap().inner);
-            let den_a =
-                ctx.add_plaintext_literal(a.den.try_into_plaintext(&ctx.data).unwrap().inner);
-
-            // Scale each numinator by the other's denominator.
-            let mul_num = ctx.add_multiplication_plaintext(b.ids[1], num_a);
-            let mul_den = ctx.add_multiplication_plaintext(b.ids[0], den_a);
+            let mul_num = ctx.add_multiplication_plaintext(b.ids[1], lit.ids[0]);
+            let mul_den = ctx.add_multiplication_plaintext(b.ids[0], lit.ids[1]);
 
             let ids = [mul_num, mul_den];
 

--- a/sunscreen/src/types/bfv/signed.rs
+++ b/sunscreen/src/types/bfv/signed.rs
@@ -300,11 +300,9 @@ impl GraphCipherConstAdd for Signed {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: i64,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
-
-            let lit = ctx.add_plaintext_literal(b.inner);
-            let add = ctx.add_addition_plaintext(a.ids[0], lit);
+            let add = ctx.add_addition_plaintext(a.ids[0], lit.ids[0]);
 
             FheProgramNode::new(&[add])
         })
@@ -368,12 +366,9 @@ impl GraphCipherConstSub for Signed {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: Self::Right,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
-
-            let lit = ctx.add_plaintext_literal(b.inner);
-            let n = ctx.add_subtraction_plaintext(a.ids[0], lit);
-
+            let n = ctx.add_subtraction_plaintext(a.ids[0], lit.ids[0]);
             FheProgramNode::new(&[n])
         })
     }
@@ -387,11 +382,9 @@ impl GraphConstCipherSub for Signed {
         a: i64,
         b: FheProgramNode<Cipher<Self::Right>>,
     ) -> FheProgramNode<Cipher<Self::Right>> {
+        let lit = Self::graph_cipher_insert(a);
         with_fhe_ctx(|ctx| {
-            let a = Self::from(a).try_into_plaintext(&ctx.data).unwrap();
-
-            let lit = ctx.add_plaintext_literal(a.inner);
-            let n = ctx.add_subtraction_plaintext(b.ids[0], lit);
+            let n = ctx.add_subtraction_plaintext(b.ids[0], lit.ids[0]);
             let n = ctx.add_negate(n);
 
             FheProgramNode::new(&[n])
@@ -435,12 +428,9 @@ impl GraphCipherConstMul for Signed {
         a: FheProgramNode<Cipher<Self::Left>>,
         b: i64,
     ) -> FheProgramNode<Cipher<Self::Left>> {
+        let lit = Self::graph_cipher_insert(b);
         with_fhe_ctx(|ctx| {
-            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
-
-            let lit = ctx.add_plaintext_literal(b.inner);
-            let add = ctx.add_multiplication_plaintext(a.ids[0], lit);
-
+            let add = ctx.add_multiplication_plaintext(a.ids[0], lit.ids[0]);
             FheProgramNode::new(&[add])
         })
     }

--- a/sunscreen/src/types/bfv/unsigned.rs
+++ b/sunscreen/src/types/bfv/unsigned.rs
@@ -258,11 +258,9 @@ macro_rules! impl_graph_cipher_op {
                         a: FheProgramNode<Cipher<Self::Left>>,
                         b: UInt<LIMBS>,
                     ) -> FheProgramNode<Cipher<Self::Left>> {
+                        let lit = Self::graph_cipher_insert(b);
                         with_fhe_ctx(|ctx| {
-                            let b = Self::from(b).try_into_plaintext(&ctx.data).unwrap();
-
-                            let lit = ctx.add_plaintext_literal(b.inner);
-                            let [<$op:lower>] = ctx.[<add_ $op_noun _plaintext>](a.ids[0], lit);
+                            let [<$op:lower>] = ctx.[<add_ $op_noun _plaintext>](a.ids[0], lit.ids[0]);
 
                             FheProgramNode::new(&[[<$op:lower>]])
                         })
@@ -301,11 +299,9 @@ impl<const LIMBS: usize> GraphConstCipherSub for Unsigned<LIMBS> {
         a: UInt<LIMBS>,
         b: FheProgramNode<Cipher<Self::Right>>,
     ) -> FheProgramNode<Cipher<Self::Right>> {
+        let lit = Self::graph_cipher_insert(a);
         with_fhe_ctx(|ctx| {
-            let a = Self::from(a).try_into_plaintext(&ctx.data).unwrap();
-
-            let lit = ctx.add_plaintext_literal(a.inner);
-            let n = ctx.add_subtraction_plaintext(b.ids[0], lit);
+            let n = ctx.add_subtraction_plaintext(b.ids[0], lit.ids[0]);
             let n = ctx.add_negate(n);
 
             FheProgramNode::new(&[n])


### PR DESCRIPTION
This came up while doing unrelated ZKP stuff. Not sure why I didn't do this in the initial PR.