### PR TITLE
Playground bump

### DIFF
--- a/sunscreen/Cargo.toml
+++ b/sunscreen/Cargo.toml
@@ -17,7 +17,9 @@ keywords = ["FHE", "BFV", "lattice", "cryptography"]
 categories = ["cryptography"]
 readme = "crates-io.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+# Load the playground with all relevant features
+[package.metadata.playground]
+features = ["bulletproofs"]
 
 [dependencies]
 bumpalo = "3.8.0"


### PR DESCRIPTION
- Bumps the playground to bring in the new multi-example feature. (https://github.com/Sunscreen-tech/rust-playground/pull/2) 
- Adds some cargo metadata so that the playground will pull in the relevant features when we do release the next version. I figure no matter what we set for defaults, if any, we'll probably want to have all ZKP backends available in the playground.

These changes have already been pushed to the preprod environment at https://preprod.playground.sunscreen.tech/ You might have to hard refresh to see them.

Here's an example of a direct link to the ZKP example: https://preprod.playground.sunscreen.tech/?example=sudoku

**Note**: the actual example code won't compile just yet, since the playground is still on the latest public sunscreen release 0.7.0. We won't deploy this to the production playground until after we cut the release on crates.io.