### PR TITLE
Fixup api docs a bit

### DIFF
--- a/benchmarks/bfv_zkp/src/bfv.rs
+++ b/benchmarks/bfv_zkp/src/bfv.rs
@@ -8,9 +8,9 @@
 use ark_ff::{BigInt, BigInteger, Fp, FpConfig, MontBackend, MontConfig, PrimeField};
 use ark_poly::univariate::DensePolynomial;
 use sunscreen::{
-    types::zkp::{Field, Mod, RnsRingPolynomial, Scale, ToBinary, ToResidues},
-    zkp_program, Application, Compiler, FieldSpec, Runtime, ZkpApplication, ZkpBackend,
-    ZkpProgramInput, ZkpRuntime,
+    types::zkp::{Field, FieldSpec, Mod, RnsRingPolynomial, Scale, ToBinary, ToResidues},
+    zkp_program, Application, Compiler, Runtime, ZkpApplication, ZkpBackend, ZkpProgramInput,
+    ZkpRuntime,
 };
 use sunscreen_zkp_backend::{bulletproofs::BulletproofsBackend, BigInt as ZkpBigInt, Proof};
 

--- a/examples/allowlist_zkp/zkp/src/lib.rs
+++ b/examples/allowlist_zkp/zkp/src/lib.rs
@@ -1,6 +1,9 @@
 use std::array;
 
-use sunscreen::{types::zkp::Field, zkp_program, zkp_var, FieldSpec};
+use sunscreen::{
+    types::zkp::{Field, FieldSpec},
+    zkp_program, zkp_var,
+};
 
 /// A ZKP proving a private entry is equal to one of the values in a list.
 #[zkp_program]

--- a/examples/ordering_zkp/src/main.rs
+++ b/examples/ordering_zkp/src/main.rs
@@ -1,7 +1,7 @@
 use sunscreen::{
     bulletproofs::BulletproofsBackend,
-    types::zkp::{BulletproofsField, ConstrainCmp, Field},
-    zkp_program, Compiler, Error, FieldSpec, ZkpRuntime,
+    types::zkp::{BulletproofsField, ConstrainCmp, Field, FieldSpec},
+    zkp_program, Compiler, Error, ZkpRuntime,
 };
 
 #[zkp_program]

--- a/examples/polynomial_zkp/src/main.rs
+++ b/examples/polynomial_zkp/src/main.rs
@@ -3,11 +3,11 @@ use std::array;
 use sunscreen::{
     bulletproofs::BulletproofsBackend,
     types::zkp::{
-        AddVar, BigInt, BulletproofsField, Coerce, Field, MulVar, NumFieldElements, ProgramNode,
-        SubVar, ToNativeFields,
+        AddVar, BigInt, BulletproofsField, Coerce, Field, FieldSpec, MulVar, NumFieldElements,
+        ProgramNode, SubVar, ToNativeFields,
     },
     zkp::{with_zkp_ctx, ZkpContextOps},
-    zkp_program, zkp_var, Compiler, Error, FieldSpec, TypeName, ZkpBackend, ZkpRuntime,
+    zkp_program, zkp_var, Compiler, Error, TypeName, ZkpBackend, ZkpRuntime,
 };
 
 /// A quotient polynomial over native field elements.

--- a/examples/polynomial_zkp/src/main.rs
+++ b/examples/polynomial_zkp/src/main.rs
@@ -6,8 +6,8 @@ use sunscreen::{
         AddVar, BigInt, BulletproofsField, Coerce, Field, MulVar, NumFieldElements, ProgramNode,
         SubVar, ToNativeFields,
     },
-    with_zkp_ctx, zkp_program, zkp_var, Compiler, Error, FieldSpec, TypeName, ZkpBackend,
-    ZkpContextOps, ZkpRuntime,
+    zkp::{with_zkp_ctx, ZkpContextOps},
+    zkp_program, zkp_var, Compiler, Error, FieldSpec, TypeName, ZkpBackend, ZkpRuntime,
 };
 
 /// A quotient polynomial over native field elements.

--- a/examples/sudoku_zkp/src/main.rs
+++ b/examples/sudoku_zkp/src/main.rs
@@ -1,7 +1,7 @@
 use sunscreen::{
     bulletproofs::BulletproofsBackend,
-    types::zkp::{BulletproofsField, Field},
-    zkp_program, zkp_var, Error, FieldSpec, ZkpProgramFnExt,
+    types::zkp::{BulletproofsField, Field, FieldSpec},
+    zkp_program, zkp_var, Error, ZkpProgramFnExt,
 };
 
 #[zkp_program]

--- a/sunscreen/benches/fractional_range_proof.rs
+++ b/sunscreen/benches/fractional_range_proof.rs
@@ -2,7 +2,7 @@ use std::time::Instant;
 
 use criterion::{criterion_group, criterion_main, Criterion};
 use sunscreen::{
-    types::zkp::{ConstrainCmp, Field, IntoProgramNode, ProgramNode},
+    types::zkp::{ConstrainCmp, Field, FieldSpec, IntoProgramNode, ProgramNode},
     *,
 };
 use sunscreen_zkp_backend::{bulletproofs::BulletproofsBackend, BigInt};

--- a/sunscreen/src/lib.rs
+++ b/sunscreen/src/lib.rs
@@ -71,9 +71,7 @@ pub use sunscreen_runtime::{
 };
 #[cfg(feature = "bulletproofs")]
 pub use sunscreen_zkp_backend::bulletproofs;
-pub use sunscreen_zkp_backend::{
-    Error as ZkpError, FieldSpec, Proof, Result as ZkpResult, ZkpBackend,
-};
+pub use sunscreen_zkp_backend::{Error as ZkpError, Proof, Result as ZkpResult, ZkpBackend};
 pub use zkp::{invoke_gadget, ZkpProgramFn, ZkpProgramFnExt};
 
 #[derive(Clone)]

--- a/sunscreen/src/lib.rs
+++ b/sunscreen/src/lib.rs
@@ -38,28 +38,14 @@
 
 mod compiler;
 mod error;
-/**
- * This module contains types used internally when compiling
- * [`fhe_program`]s.
- */
-pub mod fhe;
 mod params;
-mod zkp;
 
-/**
- * This module contains types used during [`fhe_program`] construction.
- *
- * * The [`crate::types::bfv`] module contains data types used for
- * BFV [`fhe_program`] inputs and outputs.
- * * The [`crate::types::intern`] module contains implementation details needed
- * for [`fhe_program`] construction. You shouldn't need to use these, as the `#[fhe_program]`
- * macro will automatically insert them for you as needed.
- *
- * The root of the module contains:
- * * [`Cipher`](crate::types::Cipher) is a parameterized type used to
- * denote an [`fhe_program`] input parameter as encrypted.
- */
+/// This module contains types used internally when compiling [`fhe_program`]s.
+pub mod fhe;
+/// This module contains types used when writing and compiling FHE and ZKP programs.
 pub mod types;
+/// This module contains types used internally when compiling [`zkp_program`]s.
+pub mod zkp;
 
 use fhe::{FheOperation, Literal};
 use petgraph::stable_graph::StableGraph;
@@ -88,11 +74,7 @@ pub use sunscreen_zkp_backend::bulletproofs;
 pub use sunscreen_zkp_backend::{
     Error as ZkpError, FieldSpec, Proof, Result as ZkpResult, ZkpBackend,
 };
-pub use zkp::{
-    invoke_gadget, with_zkp_ctx, ZkpContext, ZkpContextOps, ZkpData, ZkpFrontendCompilation,
-    CURRENT_ZKP_CTX,
-};
-pub use zkp::{ZkpProgramFn, ZkpProgramFnExt};
+pub use zkp::{invoke_gadget, ZkpProgramFn, ZkpProgramFnExt};
 
 #[derive(Clone)]
 /**
@@ -283,10 +265,7 @@ pub struct FrontendCompilation {
 }
 
 thread_local! {
-    /**
-     * An arena containing slices of indicies. An implementation detail of the
-     * [`fhe_program`] macro.
-     */
+    /// An arena containing slices of indicies. An implementation detail of FHE/ZKP programs.
     pub static INDEX_ARENA: RefCell<bumpalo::Bump> = RefCell::new(bumpalo::Bump::new());
 }
 

--- a/sunscreen/src/types/mod.rs
+++ b/sunscreen/src/types/mod.rs
@@ -204,7 +204,7 @@ macro_rules! fhe_var {
 /// Creates new ZKP variables from literals.
 ///
 /// ```
-/// # use sunscreen::{zkp_var, zkp_program, FieldSpec, types::zkp::Field};
+/// # use sunscreen::{zkp_var, zkp_program, types::zkp::{Field, FieldSpec}};
 /// #[zkp_program]
 /// fn equals_ten<F: FieldSpec>(a: Field<F>) {
 ///     let ten = zkp_var!(10);
@@ -215,7 +215,7 @@ macro_rules! fhe_var {
 /// You can also create arrays of variables:
 ///
 /// ```
-/// # use sunscreen::{zkp_var, zkp_program, FieldSpec, types::zkp::Field};
+/// # use sunscreen::{zkp_var, zkp_program, types::zkp::{Field, FieldSpec}};
 /// #[zkp_program]
 /// fn equals_ten<F: FieldSpec>(a: Field<F>) {
 ///     let tens = zkp_var![10, 10, 10];

--- a/sunscreen/src/types/zkp/gadgets/arithmetic.rs
+++ b/sunscreen/src/types/zkp/gadgets/arithmetic.rs
@@ -1,8 +1,8 @@
 use crypto_bigint::{NonZero, Uint};
 use subtle::{ConditionallySelectable, ConstantTimeEq, ConstantTimeGreater};
-use sunscreen_zkp_backend::{BigInt, Error as ZkpError, Gadget};
+use sunscreen_zkp_backend::{BigInt, Error as ZkpError, Gadget, Result as ZkpResult};
 
-use crate::{invoke_gadget, with_zkp_ctx, zkp::ZkpContextOps, ZkpResult};
+use crate::zkp::{invoke_gadget, with_zkp_ctx, ZkpContextOps};
 
 use super::ToUInt;
 

--- a/sunscreen/src/types/zkp/gadgets/binary.rs
+++ b/sunscreen/src/types/zkp/gadgets/binary.rs
@@ -1,6 +1,6 @@
-use sunscreen_zkp_backend::{BigInt, Gadget};
+use sunscreen_zkp_backend::{BigInt, Error as ZkpError, Gadget, Result as ZkpResult};
 
-use crate::{invoke_gadget, with_zkp_ctx, zkp::ZkpContextOps, ZkpError, ZkpResult};
+use crate::zkp::{invoke_gadget, with_zkp_ctx, ZkpContextOps};
 
 /**
  * Expands a field element into N-bit unsigned binary.

--- a/sunscreen/src/types/zkp/mod.rs
+++ b/sunscreen/src/types/zkp/mod.rs
@@ -11,7 +11,7 @@ pub use petgraph::stable_graph::NodeIndex;
 pub use program_node::*;
 pub use rns_polynomial::*;
 use sunscreen_compiler_common::TypeName;
-pub use sunscreen_zkp_backend::{BigInt, Gadget};
+pub use sunscreen_zkp_backend::{BigInt, FieldSpec, Gadget};
 
 pub use sunscreen_runtime::{ToNativeFields, ZkpProgramInputTrait};
 

--- a/sunscreen/src/types/zkp/rns_polynomial.rs
+++ b/sunscreen/src/types/zkp/rns_polynomial.rs
@@ -4,8 +4,7 @@ use sunscreen_zkp_backend::{BigInt, FieldSpec};
 
 use crate::{
     types::zkp::{Coerce, ProgramNode},
-    with_zkp_ctx,
-    zkp::ZkpContextOps,
+    zkp::{with_zkp_ctx, ZkpContextOps},
 };
 
 use super::{AddVar, Field, Mod, MulVar, NumFieldElements, ToNativeFields};

--- a/sunscreen/src/zkp/mod.rs
+++ b/sunscreen/src/zkp/mod.rs
@@ -12,23 +12,15 @@ use std::sync::Arc;
 use std::vec;
 use std::{any::Any, cell::RefCell};
 
-/**
- * An internal representation of a ZKP program specification.
- */
+/// An internal representation of a ZKP program specification.
 pub trait ZkpProgramFn<F: FieldSpec> {
-    /**
-     * Create a circuit from this specification.
-     */
+    /// Create a circuit from this specification.
     fn build(&self) -> Result<ZkpFrontendCompilation>;
 
-    /**
-     * Gets the call signature for this program.
-     */
+    /// Gets the call signature for this program.
     fn signature(&self) -> CallSignature;
 
-    /**
-     * Gets the name of this program.
-     */
+    /// Gets the name of this program.
     fn name(&self) -> &str;
 }
 
@@ -173,17 +165,29 @@ use sunscreen_compiler_common::{
 };
 
 #[derive(Clone)]
+/// Represents an operation occuring in the frontend AST of the ZKP program
 pub enum Operation {
+    /// Loads a private input by its positional index.
     PrivateInput(usize),
+    /// Loads a public input by its positional index.
     PublicInput(usize),
+    /// Loads a constant input by its positional index.
     ConstantInput(usize),
+    /// Loads a hidden input by its positional index.
     HiddenInput(usize),
+    /// An equality constraint to the provided `BigInt` value.
     Constraint(BigInt),
+    /// A constant value.
     Constant(BigInt),
+    /// An invoked gadget (which will generate more of the circuit on the backend).
     InvokeGadget(Arc<dyn Gadget>),
+    /// Addition.
     Add,
+    /// Subtraction.
     Sub,
+    /// Multiplication.
     Mul,
+    /// Negation.
     Neg,
 }
 
@@ -287,30 +291,37 @@ impl OperationTrait for Operation {
 }
 
 impl Operation {
+    /// Whether or not this operation is addition.
     pub fn is_add(&self) -> bool {
         matches!(self, Operation::Add)
     }
 
+    /// Whether or not this operation is subtraction.
     pub fn is_sub(&self) -> bool {
         matches!(self, Operation::Sub)
     }
 
+    /// Whether or not this operation is multiplication.
     pub fn is_mul(&self) -> bool {
         matches!(self, Operation::Mul)
     }
 
+    /// Whether or not this operation is negation.
     pub fn is_neg(&self) -> bool {
         matches!(self, Operation::Neg)
     }
 
+    /// Whether or not this operation is a private input.
     pub fn is_private_input(&self) -> bool {
         matches!(self, Operation::PrivateInput(_))
     }
 
+    /// Whether or not this operation is a public input.
     pub fn is_public_input(&self) -> bool {
         matches!(self, Operation::PublicInput(_))
     }
 
+    /// Whether or not this operation is a hidden input.
     pub fn is_hidden_input(&self) -> bool {
         matches!(self, Operation::HiddenInput(_))
     }

--- a/sunscreen/src/zkp/mod.rs
+++ b/sunscreen/src/zkp/mod.rs
@@ -32,8 +32,8 @@ pub trait ZkpProgramFnExt {
     /// ```rust
     /// use sunscreen::{
     ///     bulletproofs::BulletproofsBackend,
-    ///     zkp_program, types::zkp::{BulletproofsField, Field},
-    ///     FieldSpec, ZkpRuntime, ZkpProgramFnExt
+    ///     zkp_program, types::zkp::{BulletproofsField, Field, FieldSpec},
+    ///     ZkpRuntime, ZkpProgramFnExt
     /// };
     ///
     /// #[zkp_program]
@@ -54,8 +54,8 @@ pub trait ZkpProgramFnExt {
     /// ```rust
     /// use sunscreen::{
     ///     bulletproofs::BulletproofsBackend,
-    ///     types::zkp::{BulletproofsField, Field},
-    ///     zkp_program, zkp_var, FieldSpec, Compiler, Error, ZkpRuntime,
+    ///     types::zkp::{BulletproofsField, Field, FieldSpec},
+    ///     zkp_program, zkp_var, Compiler, Error, ZkpRuntime,
     /// };
     ///
     /// #[zkp_program]
@@ -96,8 +96,8 @@ pub trait ZkpProgramFnExt {
     /// ```rust
     /// use sunscreen::{
     ///     bulletproofs::BulletproofsBackend,
-    ///     zkp_program, types::zkp::{BulletproofsField, Field},
-    ///     FieldSpec, ZkpProgramFnExt
+    ///     zkp_program, types::zkp::{BulletproofsField, Field, FieldSpec},
+    ///     ZkpProgramFnExt
     /// };
     ///
     /// #[zkp_program]
@@ -130,8 +130,8 @@ pub trait ZkpProgramFnExt {
     /// ```rust
     /// use sunscreen::{
     ///     bulletproofs::BulletproofsBackend,
-    ///     zkp_program, types::zkp::{BulletproofsField, Field},
-    ///     FieldSpec, ZkpProgramFnExt
+    ///     zkp_program, types::zkp::{BulletproofsField, Field, FieldSpec},
+    ///     ZkpProgramFnExt
     /// };
     ///
     /// #[zkp_program]

--- a/sunscreen_compiler_macros/src/zkp_program.rs
+++ b/sunscreen_compiler_macros/src/zkp_program.rs
@@ -201,10 +201,10 @@ fn parse_inner(_attr_params: ZkpProgramAttrs, input_fn: ItemFn) -> Result<TokenS
         }
 
         impl <#generic_ident: #generic_bound> sunscreen::ZkpProgramFn<#generic_ident> for #zkp_program_struct_name {
-            fn build(&self) -> sunscreen::Result<sunscreen::ZkpFrontendCompilation> {
+            fn build(&self) -> sunscreen::Result<sunscreen::zkp::ZkpFrontendCompilation> {
                 use std::cell::RefCell;
                 use std::mem::transmute;
-                use sunscreen::{CURRENT_ZKP_CTX, ZkpContext, ZkpData, Error, INDEX_ARENA, Result, types::{zkp::{ProgramNode, CreateZkpProgramInput, ConstrainEq, IntoProgramNode}, TypeName}};
+                use sunscreen::{Error, INDEX_ARENA, Result, types::{zkp::{ProgramNode, CreateZkpProgramInput, ConstrainEq, IntoProgramNode}, TypeName}, zkp::{CURRENT_ZKP_CTX, ZkpContext, ZkpData}};
 
                 let mut context = ZkpContext::new(ZkpData::new());
 


### PR DESCRIPTION
In preparation for v0.8.0:

- Updated some doc comments that were specific to FHE
- Tried to create a little bit more symmetry between fhe / zkp modules and where things live. In particular moved internal stuff like `ZkpFrontendCompilation`, `CURRENT_ZKP_CTX` into `crate::zkp`, like we do for `crate::fhe`.
  - Kept `invoke_gadget` out in the root since that isn't really internal.

It's still a little messy. I think for v1 we need to be more diligent. There's a lot of cruft in the root, e.g. `FrontendCompilation` or `OperandInfo`, and it is not clear why this would live in the root versus `sunscreen::fhe` or `sunscreen::types::intern`.