### PR TITLE
Bump mdbook

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,7 @@
 	url = https://github.com/emscripten-core/emsdk.git
 [submodule "mdBook"]
 	path = mdBook
-	url = https://github.com/rickwebiii/mdBook.git
+	url = https://github.com/Sunscreen-tech/mdBook.git
 [submodule "rust-playground"]
 	path = rust-playground
 	url = https://github.com/Sunscreen-tech/rust-playground.git


### PR DESCRIPTION
Upon deployment, any code snippets requiring on hidden lines were failing to run via playground. To run them successfully you had to toggle the lines to be visible. This bump to pull in upstream changes seems to have fixed the problem.

Also switched to a fork that lives under the sunscreen org. 