### PR TITLE
Use same jit_prover ordering as specified in lib

### DIFF
--- a/sunscreen_runtime/src/runtime.rs
+++ b/sunscreen_runtime/src/runtime.rs
@@ -671,7 +671,7 @@ where
         let now = Instant::now();
 
         let prog =
-            backend.jit_prover(program, &constant_inputs, &public_inputs, &private_inputs)?;
+            backend.jit_prover(program, &private_inputs, &public_inputs, &constant_inputs)?;
 
         trace!("Prover JIT time {}s", now.elapsed().as_secs_f64());
 

--- a/sunscreen_zkp_backend/src/bulletproofs.rs
+++ b/sunscreen_zkp_backend/src/bulletproofs.rs
@@ -458,9 +458,9 @@ impl ZkpBackend for BulletproofsBackend {
     fn jit_prover(
         &self,
         prog: &crate::CompiledZkpProgram,
-        constant_inputs: &[BigInt],
-        public_inputs: &[BigInt],
         private_inputs: &[BigInt],
+        public_inputs: &[BigInt],
+        constant_inputs: &[BigInt],
     ) -> Result<ExecutableZkpProgram> {
         let constant_inputs = constant_inputs
             .iter()
@@ -475,7 +475,7 @@ impl ZkpBackend for BulletproofsBackend {
             .map(Scalar::try_from)
             .collect::<Result<Vec<Scalar>>>()?;
 
-        jit_prover::<BulletproofsFieldSpec>(prog, &constant_inputs, &public_inputs, &private_inputs)
+        jit_prover::<BulletproofsFieldSpec>(prog, &private_inputs, &public_inputs, &constant_inputs)
     }
 
     fn jit_verifier(

--- a/sunscreen_zkp_backend/src/jit.rs
+++ b/sunscreen_zkp_backend/src/jit.rs
@@ -241,9 +241,9 @@ fn validate_zkp_program(prog: &CompiledZkpProgram) -> Result<()> {
  */
 pub fn jit_prover<U>(
     prog: &CompiledZkpProgram,
-    constant_inputs: &[U::BackendField],
-    public_inputs: &[U::BackendField],
     private_inputs: &[U::BackendField],
+    public_inputs: &[U::BackendField],
+    constant_inputs: &[U::BackendField],
 ) -> Result<ExecutableZkpProgram>
 where
     U: FieldSpec,


### PR DESCRIPTION
The `lib.rs` for the zkp backend specified that the `jit_prover` API was private then public then constant inputs, but the implementation used the ordering constant then public then private. This PR makes the use uniform.