### PR TITLE
SDLP and R1CS BP shared inputs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ dependencies = [
  "ark-std",
  "derivative",
  "digest 0.10.7",
- "itertools",
+ "itertools 0.10.5",
  "num-bigint",
  "num-traits 0.2.16",
  "paste",
@@ -604,7 +604,7 @@ dependencies = [
  "clap 2.34.0",
  "criterion-plot 0.4.5",
  "csv",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "num-traits 0.2.16",
  "oorandom",
@@ -631,7 +631,7 @@ dependencies = [
  "clap 4.4.2",
  "criterion-plot 0.5.0",
  "is-terminal",
- "itertools",
+ "itertools 0.10.5",
  "num-traits 0.2.16",
  "once_cell",
  "oorandom",
@@ -650,7 +650,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -660,7 +660,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1507,6 +1507,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
 dependencies = [
  "either",
 ]
@@ -2784,6 +2793,7 @@ dependencies = [
  "criterion 0.3.6",
  "digest 0.9.0",
  "hex",
+ "itertools 0.11.0",
  "merlin",
  "rand",
  "rand_chacha",
@@ -2898,6 +2908,8 @@ dependencies = [
  "bincode",
  "crossbeam",
  "log",
+ "logproof",
+ "merlin",
  "num_cpus",
  "petgraph",
  "rayon",
@@ -2908,7 +2920,9 @@ dependencies = [
  "serde_json",
  "static_assertions",
  "sunscreen_compiler_common",
+ "sunscreen_curve25519",
  "sunscreen_fhe_program",
+ "sunscreen_math",
  "sunscreen_zkp_backend",
  "thiserror",
 ]
@@ -2922,6 +2936,7 @@ dependencies = [
  "log",
  "merlin",
  "petgraph",
+ "rand",
  "serde",
  "static_assertions",
  "sunscreen_bulletproofs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2909,7 +2909,6 @@ dependencies = [
  "bincode",
  "crossbeam",
  "log",
- "logproof",
  "merlin",
  "num_cpus",
  "petgraph",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ dependencies = [
  "criterion 0.5.1",
  "crypto-bigint",
  "digest 0.10.7",
+ "log",
  "merlin",
  "once_cell",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,4 @@ sunscreen_compiler_common = { version = "0.8.1", path = "./sunscreen_compiler_co
 sunscreen_math = { version = "0.8.1", path = "./sunscreen_math" }
 sunscreen_math_macros = { version = "0.8.1", path = "./sunscreen_math_macros" }
 seal_fhe = { version = "0.8.1", path = "./seal_fhe" }
+logproof = { version = "0.8.1", path = "./logproof" }

--- a/logproof/Cargo.toml
+++ b/logproof/Cargo.toml
@@ -10,6 +10,7 @@ bitvec = { workspace = true }
 bytemuck = { workspace = true }
 crypto-bigint = { workspace = true }
 curve25519-dalek = { workspace = true }
+log = { workspace = true }
 merlin = { workspace = true }
 sha3 = { workspace = true }
 digest = { workspace = true }

--- a/logproof/src/generators.rs
+++ b/logproof/src/generators.rs
@@ -92,10 +92,7 @@ impl LogProofGenerators {
                 })
                 .collect_into_vec(&mut g);
 
-            g.into_iter()
-                .take(n)
-                .collect::<Vec<Vec<RistrettoPoint>>>()
-                .concat()
+            g.concat()
         }
 
         Self {

--- a/logproof/src/inner_product.rs
+++ b/logproof/src/inner_product.rs
@@ -6,6 +6,7 @@ use curve25519_dalek::{
 };
 use digest::ExtendableOutput;
 use digest::XofReader;
+use log::trace;
 use merlin::Transcript;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -281,13 +282,13 @@ impl InnerProductProof {
 
         let a = transcript.challenge_point(b"a");
 
-        println!("Prefold {}s", now.elapsed().as_secs_f64());
+        trace!("Prefold {}s", now.elapsed().as_secs_f64());
 
         let now = Instant::now();
 
         let (g, h, t_pprime) = self.folding_verifier(transcript, &vk, &a, &g, &h)?;
 
-        println!("Fold {}s", now.elapsed().as_secs_f64());
+        trace!("Fold {}s", now.elapsed().as_secs_f64());
 
         let now = Instant::now();
 
@@ -305,8 +306,8 @@ impl InnerProductProof {
         let lhs = t_pprime * c + w + w_prime * c_inv;
         let rhs = g * self.z_1 + h * self.z_2 + a * (c_inv * self.z_1 * self.z_2) + u * self.tau;
 
-        println!("Post fold {}s", now.elapsed().as_secs_f64());
-        println!("Verify time {}s", total.elapsed().as_secs_f64());
+        trace!("Post fold {}s", now.elapsed().as_secs_f64());
+        trace!("Verify time {}s", total.elapsed().as_secs_f64());
 
         if lhs == rhs {
             Ok(())
@@ -432,7 +433,7 @@ impl InnerProductProof {
         let now = Instant::now();
         let g = parallel_multiscalar_multiplication(&s, g);
         let h = parallel_multiscalar_multiplication(&s_inv, h);
-        println!(
+        trace!(
             "MSM {}s: {} SM/s",
             now.elapsed().as_secs_f64(),
             (2. * n as f64) / now.elapsed().as_secs_f64()

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -23,6 +23,7 @@ use std::{
 use bitvec::{slice::BitSlice, vec::BitVec};
 use crypto_bigint::Uint;
 use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar, traits::Identity};
+use log::trace;
 use merlin::Transcript;
 use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -692,29 +693,29 @@ impl LogProof {
 
         let (alpha, beta, gamma, phi, psi) = Self::create_challenges(vk, transcript);
 
-        println!("Create challenges {}s", now.elapsed().as_secs_f64());
+        trace!("Create challenges {}s", now.elapsed().as_secs_f64());
 
         let now = Instant::now();
 
         let g_prime = Self::compute_g_prime(g, &phi);
 
-        println!("g_prime {}s", now.elapsed().as_secs_f64());
+        trace!("g_prime {}s", now.elapsed().as_secs_f64());
 
         let now = Instant::now();
 
         let v = Self::compute_v(vk, alpha, &beta, &gamma);
 
-        println!("v {}s", now.elapsed().as_secs_f64());
+        trace!("v {}s", now.elapsed().as_secs_f64());
         let now = Instant::now();
 
         let t = Self::compute_t(&self.w, &g_prime, h, &phi, &psi, &v);
-        println!("t {}s", now.elapsed().as_secs_f64());
+        trace!("t {}s", now.elapsed().as_secs_f64());
 
         let now = Instant::now();
 
         let x = Self::compute_x(vk, &gamma, &alpha, &beta, &phi, &psi, &v);
 
-        println!("x {}s", now.elapsed().as_secs_f64());
+        trace!("x {}s", now.elapsed().as_secs_f64());
 
         let ip_vk = inner_product::VerifierKnowledge { t, x };
 

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -196,7 +196,7 @@ where
     }
 
     /**
-     * Rannges in the serialized coefficients of S corresponding to the bounds
+     * Ranges in the serialized coefficients of S corresponding to the bounds
      */
     pub fn b_slices(&self) -> Vec<Vec<Range<usize>>> {
         let mut b_ranges: Vec<Vec<Range<usize>>> = (0..self.bounds.rows)
@@ -371,8 +371,13 @@ where
         Self { s: s.clone(), vk }
     }
 
-    /// Currently we only really use this to pull out the first n bits, but we
-    /// could also export based on the index.
+    /**
+     * Pull out the binary expansion of a component of the witness S based on
+     * the index into S.
+     *
+     * # Panics
+     * * If the index is out of bounds
+     */
     pub fn s_binary_by_index(&self, index: (usize, usize)) -> BitVec {
         let s_piece = self.s[index].clone();
         let s_piece = Matrix::new_with_data(1, 1, &[s_piece]);

--- a/sunscreen_runtime/Cargo.toml
+++ b/sunscreen_runtime/Cargo.toml
@@ -21,7 +21,6 @@ bincode = { workspace = true }
 crossbeam = { workspace = true }
 curve25519-dalek = { workspace = true }
 log = { workspace = true }
-logproof = { workspace = true }
 merlin = { workspace = true }
 seal_fhe = { workspace = true }
 sunscreen_fhe_program = { workspace = true }

--- a/sunscreen_runtime/Cargo.toml
+++ b/sunscreen_runtime/Cargo.toml
@@ -19,10 +19,14 @@ readme = "crates-io.md"
 [dependencies]
 bincode = { workspace = true }
 crossbeam = { workspace = true }
+curve25519-dalek = { workspace = true }
 log = { workspace = true }
+logproof = { workspace = true }
+merlin = { workspace = true }
 seal_fhe = { workspace = true }
 sunscreen_fhe_program = { workspace = true }
 sunscreen_compiler_common = { workspace = true }
+sunscreen_math = { workspace = true }
 sunscreen_zkp_backend = { workspace = true }
 petgraph = { workspace = true }
 num_cpus = { workspace = true }

--- a/sunscreen_zkp_backend/Cargo.toml
+++ b/sunscreen_zkp_backend/Cargo.toml
@@ -21,6 +21,7 @@ crypto-bigint = { workspace = true }
 merlin = { workspace = true, optional = true }
 bumpalo = { workspace = true }
 petgraph = { workspace = true }
+rand = { workspace = true }
 sunscreen_compiler_common = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }

--- a/sunscreen_zkp_backend/src/bulletproofs.rs
+++ b/sunscreen_zkp_backend/src/bulletproofs.rs
@@ -480,7 +480,7 @@ impl BulletproofVerifierParameters {
 }
 
 impl BulletproofProverParameters {
-    /// Create a [`BulletproofParameters`].
+    /// Create a [`BulletproofProverParameters`].
     pub fn new(
         verifier_parameters: BulletproofVerifierParameters,
         blinding_factor: Scalar,

--- a/sunscreen_zkp_backend/src/bulletproofs.rs
+++ b/sunscreen_zkp_backend/src/bulletproofs.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use bulletproofs::{
-    r1cs::{ConstraintSystem, LinearCombination, Prover, R1CSError, R1CSProof, Verifier},
+    r1cs::{ConstraintSystem, LinearCombination, Metrics, Prover, R1CSError, R1CSProof, Verifier},
     BulletproofGens, PedersenGens,
 };
 use crypto_bigint::{Limb, Uint};
@@ -12,12 +12,13 @@ use curve25519_dalek::scalar::Scalar;
 use log::trace;
 use merlin::Transcript;
 use petgraph::stable_graph::NodeIndex;
+use rand::thread_rng;
 use serde::{Deserialize, Serialize};
 use sunscreen_compiler_common::{forward_traverse, GraphQuery};
 
 use crate::{
-    exec::Operation, jit::jit_verifier, jit_prover, BigInt, Error, ExecutableZkpProgram, FieldSpec,
-    Proof, Result, ZkpBackend,
+    exec::Operation, jit::jit_verifier, jit_prover, BigInt, CompiledZkpProgram, Error,
+    ExecutableZkpProgram, FieldSpec, Proof, Result, ZkpBackend,
 };
 
 #[derive(Clone)]
@@ -107,7 +108,7 @@ struct BulletproofsCircuit {
 /**
  * A verifiable proof in the Bulletproofs R1CS system.
  */
-pub struct BulletproofsR1CSProof(R1CSProof);
+pub struct BulletproofsR1CSProof(pub R1CSProof);
 
 impl BulletproofsCircuit {
     /**
@@ -119,10 +120,9 @@ impl BulletproofsCircuit {
         }
     }
 
-    fn make_transcript(len: usize) -> Transcript {
+    fn make_base_transcript() -> Transcript {
         let mut transcript = Transcript::new(b"R1CS");
         transcript.append_message(b"dom-sep", b"R1CS proof");
-        transcript.append_u64(b"gen-len", len as u64);
 
         transcript
     }
@@ -327,6 +327,74 @@ impl BulletproofsBackend {
     pub fn new() -> Self {
         Self
     }
+
+    /// Generate a prover from a given circuit. The purpose of this is to be
+    /// able to extract information from the prover without actually running it.
+    fn prover_with_circuit<'g>(
+        &'g self,
+        program: &CompiledZkpProgram,
+        private_inputs: &[BigInt],
+        public_inputs: &[BigInt],
+        constant_inputs: &[BigInt],
+        pc_gens: &'g PedersenGens,
+        transcript: &'g mut Transcript,
+    ) -> Result<Prover<'g, &mut Transcript>> {
+        let prog = self.jit_prover(program, private_inputs, public_inputs, constant_inputs)?;
+
+        let inputs = [public_inputs, private_inputs].concat();
+        // Convert the inputs to Scalars
+        let inputs = inputs
+            .iter()
+            .map(|x| x.try_into())
+            .collect::<Result<Vec<Scalar>>>()
+            .unwrap();
+
+        let mut circuit = BulletproofsCircuit::new(prog.node_count());
+
+        let mut prover = Prover::new(pc_gens, transcript);
+
+        let _ = circuit.gen_circuit(&prog, &mut prover, |x| Some(inputs[x]));
+
+        Ok(prover)
+    }
+
+    /// Returns the prover metrics for the given program.
+    pub fn metrics(
+        &self,
+        program: &CompiledZkpProgram,
+        private_inputs: &[BigInt],
+        public_inputs: &[BigInt],
+        constant_inputs: &[BigInt],
+    ) -> Result<Metrics> {
+        let pc_gens = PedersenGens::default();
+        let mut transcript = Transcript::new(b"dummy");
+
+        let prover = self.prover_with_circuit(
+            program,
+            private_inputs,
+            public_inputs,
+            constant_inputs,
+            &pc_gens,
+            &mut transcript,
+        )?;
+
+        Ok(prover.metrics())
+    }
+
+    /// Returns the number of constraints in the given program.
+    pub fn constraint_count(
+        &self,
+        program: &CompiledZkpProgram,
+        private_inputs: &[BigInt],
+        public_inputs: &[BigInt],
+        constant_inputs: &[BigInt],
+    ) -> Result<usize> {
+        let prog = self.jit_prover(program, private_inputs, public_inputs, constant_inputs)?;
+
+        let constraint_count = constraint_count(&prog)?;
+
+        Ok(constraint_count)
+    }
 }
 
 impl Default for BulletproofsBackend {
@@ -335,6 +403,7 @@ impl Default for BulletproofsBackend {
     }
 }
 
+/// Get the number of constraints in the given program.
 fn constraint_count(graph: &ExecutableZkpProgram) -> Result<usize> {
     let mut count = 0;
     let mut input_count = 0usize;
@@ -370,10 +439,108 @@ fn constraint_count(graph: &ExecutableZkpProgram) -> Result<usize> {
     Ok(count)
 }
 
+/// Parameters for verifying Bulletproof circuit.
+#[derive(Clone)]
+pub struct BulletproofVerifierParameters {
+    pedersen_generators: PedersenGens,
+    bulletproof_generators: BulletproofGens,
+    shared_length: usize,
+}
+
+/// Parameters for proving a Bulletproof circuit.
+#[derive(Clone)]
+pub struct BulletproofProverParameters {
+    verifier_parameters: BulletproofVerifierParameters,
+    blinding_factor: Scalar,
+}
+
+impl BulletproofVerifierParameters {
+    /// Create a [`BulletproofVerifierParameters`].
+    pub fn new(
+        pedersen_generators: PedersenGens,
+        bulletproof_generators: BulletproofGens,
+        shared_length: usize,
+    ) -> Self {
+        Self {
+            pedersen_generators,
+            bulletproof_generators,
+            shared_length,
+        }
+    }
+
+    /// Return the Pedersen generators.
+    pub fn pedersen_generators(&self) -> &PedersenGens {
+        &self.pedersen_generators
+    }
+
+    /// Return the Bulletproof generators.
+    pub fn bulletproof_generators(&self) -> &BulletproofGens {
+        &self.bulletproof_generators
+    }
+}
+
+impl BulletproofProverParameters {
+    /// Create a [`BulletproofParameters`].
+    pub fn new(
+        verifier_parameters: BulletproofVerifierParameters,
+        blinding_factor: Scalar,
+    ) -> Self {
+        Self {
+            verifier_parameters,
+            blinding_factor,
+        }
+    }
+}
+
 impl ZkpBackend for BulletproofsBackend {
     type Field = BulletproofsFieldSpec;
 
+    type ProverParameters = BulletproofProverParameters;
+    type VerifierParameters = BulletproofVerifierParameters;
+
+    /**
+     * Create a proof for the given executable Sunscreen
+     * program with the given inputs.
+     */
     fn prove(&self, graph: &ExecutableZkpProgram, inputs: &[BigInt]) -> Result<Proof> {
+        let mut transcript = BulletproofsCircuit::make_base_transcript();
+
+        let constraint_count = constraint_count(graph)?;
+
+        let mut rng = {
+            let mut builder = transcript.build_rng();
+
+            // commit to all the inputs, including the private ones.
+            for input in inputs {
+                let words = input.0.as_words();
+                let bytes: Vec<u8> = words.iter().flat_map(|x| x.to_le_bytes()).collect();
+
+                builder = builder.rekey_with_witness_bytes(b"input", &bytes);
+            }
+
+            // And throw in some thread RNG for good measure. The bulletproofs
+            // library does this as well.
+            builder.finalize(&mut thread_rng())
+        };
+        let blinding_factor = Scalar::random(&mut rng);
+
+        let verifier_parameters = Self::VerifierParameters::new(
+            PedersenGens::default(),
+            BulletproofGens::new(2 * constraint_count, 1),
+            0,
+        );
+
+        let parameters = Self::ProverParameters::new(verifier_parameters, blinding_factor);
+        self.prove_with_parameters(graph, inputs, &parameters, &mut transcript)
+    }
+
+    fn prove_with_parameters(
+        &self,
+        graph: &ExecutableZkpProgram,
+        inputs: &[BigInt],
+        parameters: &Self::ProverParameters,
+        transcript: &mut Transcript,
+    ) -> Result<Proof> {
         let expected_input_count = graph
             .node_weights()
             .filter(|x| matches!(x.operation, Operation::Input(_)))
@@ -395,14 +562,15 @@ impl ZkpBackend for BulletproofsBackend {
             .map(|x| x.try_into())
             .collect::<Result<Vec<Scalar>>>()?;
 
-        let transcript = BulletproofsCircuit::make_transcript(constraint_count);
-
-        let (pedersen_gens, bulletproof_gens) =
-            BulletproofsCircuit::make_gens(2 * constraint_count);
+        transcript.append_message(b"dom-sep", b"R1CS proof");
+        transcript.append_u64(b"gen-len", constraint_count as u64);
 
         let mut circuit = BulletproofsCircuit::new(graph.node_count());
 
-        let mut prover = Prover::new(&pedersen_gens, transcript);
+        let mut prover = Prover::new(
+            &parameters.verifier_parameters.pedersen_generators,
+            transcript,
+        );
 
         let now = Instant::now();
 
@@ -413,7 +581,13 @@ impl ZkpBackend for BulletproofsBackend {
 
         let now = Instant::now();
 
-        let proof = prover.prove(&bulletproof_gens)?;
+        let proof = prover
+            .prove_with_parameters_and_return_transcript(
+                &parameters.verifier_parameters.bulletproof_generators,
+                parameters.verifier_parameters.shared_length,
+                &parameters.blinding_factor,
+            )
+            .map(|(proof, _)| proof)?;
 
         trace!("Bulletproofs prover time {}s", now.elapsed().as_secs_f64());
 
@@ -421,6 +595,24 @@ impl ZkpBackend for BulletproofsBackend {
     }
 
     fn verify(&self, graph: &ExecutableZkpProgram, proof: &Proof) -> Result<()> {
+        let constraint_count = constraint_count(graph)?;
+        let mut transcript = BulletproofsCircuit::make_base_transcript();
+
+        let (pedersen_gens, bulletproof_gens) =
+            BulletproofsCircuit::make_gens(2 * constraint_count);
+
+        let parameters = Self::VerifierParameters::new(pedersen_gens, bulletproof_gens, 0);
+
+        self.verify_with_parameters(graph, proof, &parameters, &mut transcript)
+    }
+
+    fn verify_with_parameters(
+        &self,
+        graph: &ExecutableZkpProgram,
+        proof: &Proof,
+        parameters: &Self::VerifierParameters,
+        transcript: &mut Transcript,
+    ) -> Result<()> {
         let proof = match proof {
             Proof::Bulletproofs(x) => x,
             _ => {
@@ -432,9 +624,8 @@ impl ZkpBackend for BulletproofsBackend {
 
         let constraint_count = constraint_count(graph)?;
 
-        let transcript = BulletproofsCircuit::make_transcript(constraint_count);
-        let (pedersen_gens, bulletproof_gens) =
-            BulletproofsCircuit::make_gens(2 * constraint_count);
+        transcript.append_message(b"dom-sep", b"R1CS proof");
+        transcript.append_u64(b"gen-len", constraint_count as u64);
 
         let mut circuit = BulletproofsCircuit::new(graph.node_count());
 
@@ -448,7 +639,11 @@ impl ZkpBackend for BulletproofsBackend {
 
         let now = Instant::now();
 
-        verifier.verify(&proof.0, &pedersen_gens, &bulletproof_gens)?;
+        verifier.verify(
+            &proof.0,
+            &parameters.pedersen_generators,
+            &parameters.bulletproof_generators,
+        )?;
 
         trace!("Bulletproofs verify time {}s", now.elapsed().as_secs_f64());
 
@@ -462,7 +657,7 @@ impl ZkpBackend for BulletproofsBackend {
         public_inputs: &[BigInt],
         constant_inputs: &[BigInt],
     ) -> Result<ExecutableZkpProgram> {
-        let constant_inputs = constant_inputs
+        let private_inputs = private_inputs
             .iter()
             .map(Scalar::try_from)
             .collect::<Result<Vec<Scalar>>>()?;
@@ -470,7 +665,7 @@ impl ZkpBackend for BulletproofsBackend {
             .iter()
             .map(Scalar::try_from)
             .collect::<Result<Vec<Scalar>>>()?;
-        let private_inputs = private_inputs
+        let constant_inputs = constant_inputs
             .iter()
             .map(Scalar::try_from)
             .collect::<Result<Vec<Scalar>>>()?;

--- a/sunscreen_zkp_backend/src/lib.rs
+++ b/sunscreen_zkp_backend/src/lib.rs
@@ -27,6 +27,7 @@ use crypto_bigint::{
 pub use error::*;
 pub use exec::ExecutableZkpProgram;
 pub use jit::{jit_prover, jit_verifier, CompiledZkpProgram, Operation};
+use merlin::Transcript;
 use petgraph::stable_graph::NodeIndex;
 use serde::{Deserialize, Serialize};
 
@@ -370,6 +371,12 @@ pub trait ZkpBackend {
      */
     type Field: FieldSpec;
 
+    /// The parameters for prover manually passed into the backend.
+    type ProverParameters;
+
+    /// The parameters for verifier manually passed into the backend.
+    type VerifierParameters;
+
     /**
      * Create a proof for the given executable Sunscreen
      * program with the given inputs.
@@ -377,10 +384,34 @@ pub trait ZkpBackend {
     fn prove(&self, graph: &ExecutableZkpProgram, inputs: &[BigInt]) -> Result<Proof>;
 
     /**
+     * Create a proof for the given executable Sunscreen
+     * program with the given inputs.
+     */
+    fn prove_with_parameters(
+        &self,
+        graph: &ExecutableZkpProgram,
+        inputs: &[BigInt],
+        parameters: &Self::ProverParameters,
+        transcript: &mut Transcript,
+    ) -> Result<Proof>;
+
+    /**
      * Verify the given proof for the given executable
      * Sunscreen program.
      */
     fn verify(&self, graph: &ExecutableZkpProgram, proof: &Proof) -> Result<()>;
+
+    /**
+     * Verify the given proof for the given executable
+     * Sunscreen program.
+     */
+    fn verify_with_parameters(
+        &self,
+        graph: &ExecutableZkpProgram,
+        proof: &Proof,
+        parameters: &Self::VerifierParameters,
+        transcript: &mut Transcript,
+    ) -> Result<()>;
 
     /**
      * JIT the given frontend-compiled ZKP program


### PR DESCRIPTION
Enables pieces of the BP R1CS implementation to be shared with the SDLP portion. Note that the PR for the `sunscreen_bulletproofs` (https://github.com/Sunscreen-tech/bulletproofs_zkcrypto/pull/1) must be merged first.

An example program linking the BFV SDLP and a balance check can be seen here. The next PR will be making this into a pair of functions (prove and verify) that users can call more easily (with inputs being the LatticeProblem, the ZKP, and the ZKP inputs).

```rust
use bitvec::vec::BitVec;
use curve25519_dalek::{ristretto::RistrettoPoint, scalar::Scalar};
use merlin::Transcript;
use sunscreen::bulletproofs::{BulletproofProverParameters, BulletproofVerifierParameters};
use sunscreen::types::zkp::BigInt;
use sunscreen::{
    bulletproofs::BulletproofsBackend,
    types::zkp::{BulletproofsField, ConstrainCmp, Field, FieldSpec, ProgramNode},
    zkp_program, zkp_var, Compiler, Error, SecurityLevel, ZkpProgramInput, ZkpRuntime,
};
use sunscreen_bulletproofs::{BulletproofGens, PedersenGens};

use seal_fhe::{
    BFVScalarEncoder, BfvEncryptionParametersBuilder, CoefficientModulus, Context, Encryptor,
    KeyGenerator, PlainModulus, PolynomialArray,
};

use logproof::{
    linear_algebra::Matrix,
    math::{make_poly, next_higher_power_of_two, rand256},
    rings::{SealQ128_1024, ZqRistretto},
    test::{
        bfv_delta, convert_to_polynomial, convert_to_smallint, strip_trailing_value, LatticeProblem,
    },
    Bounds, LogProof, LogProofGenerators, LogProofProverKnowledge, LogProofTranscript,
};

use sunscreen_math::{
    poly::Polynomial,
    ring::{BarrettBackend, BarrettConfig, Zq},
    Zero,
};

fn from_twos_complement_field_element<F: FieldSpec, const N: usize>(
    x: [ProgramNode<Field<F>>; N],
) -> ProgramNode<Field<F>> {
    let mut x_recon = zkp_var!(0);

    for (i, x_i) in x.iter().enumerate().take(N - 1) {
        x_recon = x_recon + (zkp_var!(2i64.pow(i as u32)) * (*x_i));
    }

    x_recon = x_recon + zkp_var!(-(2i64.pow((N - 1) as u32))) * x[N - 1];

    x_recon
}

fn from_twos_complement_int(x: &BitVec) -> i64 {
    let mut x_recon = 0;

    for i in 0..(x.len() - 1) {
        x_recon += 2i64.pow(i as u32) * x[i] as i64;
    }

    x_recon -= 2i64.pow((x.len() - 1) as u32) * x[x.len() - 1] as i64;

    x_recon
}

// Can represent programs up to a certain value
#[zkp_program]
fn valid_transaction<F: FieldSpec>(
    #[private] x: [Field<F>; 15],
    #[private] a: Field<F>,
    #[public] balance: Field<F>,
) {
    let lower_bound = zkp_var!(0);

    // Reconstruct x from the bag of bits
    let x_recon = from_twos_complement_field_element(x);

    // Constraint that x is less than or equal to balance
    balance.constrain_ge_bounded(x_recon, 64);

    // Constraint that x is greater than or equal to zero
    lower_bound.constrain_le_bounded(x_recon, 64);

    balance.constrain_ge_bounded(a, 64);
}

fn test_seal_linear_relation<B, const N: usize>(
    message: u64,
    degree: u64,
    plain_modulus: u64,
) -> LatticeProblem<Zq<N, BarrettBackend<N, B>>>
where
    B: BarrettConfig<N>,
{
    let degree = degree;

    let plain_modulus = PlainModulus::raw(plain_modulus).unwrap();
    let coeff_modulus = CoefficientModulus::bfv_default(degree, SecurityLevel::TC128).unwrap();

    // Calculate the data coefficient modulus, which for fields with more
    // that one modulus in the coefficient modulus set is equal to the
    // product of all but the last moduli in the set.
    let mut data_modulus = ZqRistretto::from(1);

    if coeff_modulus.len() == 1 {
        data_modulus = data_modulus * ZqRistretto::from(coeff_modulus[0].value());
    } else {
        for modulus in coeff_modulus.iter().take(coeff_modulus.len() - 1) {
            data_modulus = data_modulus * ZqRistretto::from(modulus.value());
        }
    }

    // Generate encryption parameters and encrypt/decrypt functions.
    let params = BfvEncryptionParametersBuilder::new()
        .set_poly_modulus_degree(degree)
        .set_coefficient_modulus(coeff_modulus.clone())
        .set_plain_modulus(plain_modulus.clone())
        .build()
        .unwrap();

    let ctx = Context::new(&params, false, SecurityLevel::TC128).unwrap();
    let gen = KeyGenerator::new(&ctx).unwrap();

    let encoder = BFVScalarEncoder::new();

    let public_key = gen.create_public_key();
    let secret_key = gen.secret_key();

    let encryptor = Encryptor::with_public_and_secret_key(&ctx, &public_key, &secret_key).unwrap();

    // Generate plaintext data
    let plaintext = encoder.encode_unsigned(message).unwrap();

    // Generate an encrypted message with components
    let (ciphertext, u_exported, e_exported, r_exported) = encryptor
        // .encrypt_return_components(&plaintext, true, None)
        .encrypt_return_components(&plaintext)
        .unwrap();

    // Convert all components into their polynomial representations in the
    // fields we use in this package.
    let m = Polynomial {
        coeffs: strip_trailing_value(
            (0..plaintext.len())
                .map(|i| Zq::from(plaintext.get_coefficient(i)))
                .collect::<Vec<_>>(),
            Zq::zero(),
        ),
    };

    let u = convert_to_polynomial(u_exported.clone()).pop().unwrap();
    let u_small = convert_to_smallint(&coeff_modulus, u_exported.clone());

    let mut es = convert_to_polynomial(e_exported.clone());
    let e_1 = es.remove(0);
    let e_2 = es.remove(0);
    let e_small = convert_to_smallint(&coeff_modulus, e_exported.clone());

    let mut cs =
        convert_to_polynomial(PolynomialArray::new_from_ciphertext(&ctx, &ciphertext).unwrap());
    let c_0 = cs.remove(0);
    let c_1 = cs.remove(0);

    let mut pk =
        convert_to_polynomial(PolynomialArray::new_from_public_key(&ctx, &public_key).unwrap());
    let p_0 = pk.remove(0);
    let p_1 = pk.remove(0);

    let r_coeffs = (0..r_exported.len())
        .map(|i| r_exported.get_coefficient(i))
        .collect::<Vec<u64>>();
    let r = Polynomial {
        coeffs: r_coeffs
            .iter()
            .map(|r_i| Zq::from(*r_i))
            .collect::<Vec<_>>(),
    };

    // Delta is the constant polynomial with floor (q/t) as it's DC compopnent.
    let delta_dc = bfv_delta(data_modulus, plain_modulus.value());
    let delta_dc = Zq::try_from(delta_dc).unwrap();

    let delta = Polynomial {
        coeffs: vec![delta_dc],
    };

    // Set up the BFV equations.
    let one = make_poly(&[1]);
    let zero = make_poly(&[]);

    let a = Matrix::<Polynomial<_>>::from([
        [
            delta.clone(),
            one.clone(),
            p_0.clone(),
            one.clone(),
            zero.clone(),
        ],
        [
            zero.clone(),
            zero.clone(),
            p_1.clone(),
            zero.clone(),
            one.clone(),
        ],
    ]);

    let s = Matrix::<Polynomial<_>>::from([
        [m.clone()],
        [r.clone()],
        [u.clone()],
        [e_1.clone()],
        [e_2.clone()],
    ]);

    // Set up the field polymonial divisor (x^N + 1).
    let mut f_components = vec![0; (degree + 1) as usize];
    f_components[0] = 1;
    f_components[degree as usize] = 1;
    let f = make_poly(&f_components);

    // We do this without the polynomial division and then perform that at
    // the end.
    let mut t = &a * &s;

    // Divide back to a polynomial of at max degree `degree`
    let t_0 = t[(0, 0)].vartime_div_rem_restricted_rhs(&f).1;
    let t_1 = t[(1, 0)].vartime_div_rem_restricted_rhs(&f).1;
    t[(0, 0)] = t_0;
    t[(1, 0)] = t_1;

    // Test that our equations match the matrix result.
    let t_0_from_eq = (delta * &m).vartime_div_rem_restricted_rhs(&f).1
        + r.clone()
        + (p_0 * &u).vartime_div_rem_restricted_rhs(&f).1
        + e_1;

    let t_1_from_eq = (p_1 * &u).vartime_div_rem_restricted_rhs(&f).1 + e_2;

    // Assertions that the SEAL ciphertext matches our calculated one. We
    // use panics here to avoid the large printout from assert_eq.

    if t[(0, 0)] != t_0_from_eq {
        panic!("Matrix and written out equation match for t_0");
    }

    if t[(1, 0)] != t_1_from_eq {
        panic!("Matrix and written out equation match for t_1");
    }

    if t[(0, 0)] != c_0 {
        panic!("t_0 and c_0 are not equal");
    }

    if t[(1, 0)] != c_1 {
        panic!("t_1 and c_1 are not equal");
    }

    // Assert that the equations are equal when written up as a matrix (this
    // should trivially pass if the above assertions pass)
    assert_eq!(t, Matrix::<Polynomial<_>>::from([[c_0], [c_1]]));

    // Calculate bounds for the zero knowledge proof
    let mut m_coeffs = (0..plaintext.len())
        .map(|i| plaintext.get_coefficient(i) as i64)
        .collect::<Vec<i64>>();

    m_coeffs.resize(degree as usize, 0);

    let mut r_coeffs = (0..r_exported.len())
        .map(|i| r_exported.get_coefficient(i) as i64)
        .collect::<Vec<i64>>();

    r_coeffs.resize(degree as usize, 0);

    let s_components = vec![
        m_coeffs,
        r_coeffs,
        u_small[0].clone(),
        e_small[0].clone(),
        e_small[1].clone(),
    ];

    let s_components_bounds = s_components
        .into_iter()
        .map(|v| {
            Bounds(
                v.into_iter()
                    .map(|x| {
                        if x == 0 {
                            0
                        } else {
                            next_higher_power_of_two(x.unsigned_abs())
                        }
                    })
                    .collect::<Vec<u64>>(),
            )
        })
        .collect::<Vec<Bounds>>();

    let b: Matrix<Bounds> = Matrix::from(s_components_bounds);

    LatticeProblem { a, s, t, f, b }
}

fn zero_knowledge_proof<B, const N: usize>(
    message: u64,
    degree: u64,
    plain_modulus: u64,
    transcript: &mut Transcript,
) -> (LogProof, BitVec, Vec<RistrettoPoint>, Scalar)
where
    B: BarrettConfig<N>,
{
    let LatticeProblem { a, s, t, f, b } =
        test_seal_linear_relation::<B, N>(message, degree, plain_modulus);

    let pk = LogProofProverKnowledge::new(&a, &s, &t, &b, &f);

    let total_bits = pk.vk.b()[(0, 0)].iter().sum::<u64>() as usize;

    let s_binary = pk.s_binary_by_index((0, 0));

    // We will not verify for now, verify on joint
    let mut verify_transcript = transcript.clone();

    let gens = LogProofGenerators::new(pk.vk.l() as usize);
    let u = PedersenGens::default().B_blinding;

    // Note that this is half rho
    let half_rho = Scalar::from_bits(rand256());
    let proof =
        LogProof::create_with_shared(transcript, &pk, &gens.g, &gens.h, &u, &half_rho, &[(0, 0)]);

    proof
        .verify(&mut verify_transcript, &pk.vk, &gens.g, &gens.h, &u)
        .unwrap();

    let l = transcript.challenge_scalar(b"verify");
    let r = verify_transcript.challenge_scalar(b"verify");

    assert_eq!(l, r);

    (proof, s_binary, gens.h[0..total_bits].to_vec(), half_rho)
}

fn main() -> Result<(), Error> {
    let app = Compiler::new()
        .zkp_backend::<BulletproofsBackend>()
        .zkp_program(valid_transaction)
        .compile()?;

    let valid_transaction_zkp = app.get_zkp_program(valid_transaction).unwrap();

    let runtime = ZkpRuntime::new(BulletproofsBackend::new())?;

    // in binary:  010111011011111
    //             010111011011111
    let x = 11999u64;
    let mut transcript = Transcript::new(b"valid_encryption_and_zkp");

    // Prove the encryption is valid
    let (proof_sdlp, msg_bits, shared_gens, half_rho) =
        zero_knowledge_proof::<SealQ128_1024, 1>(x, 1024, 12289, &mut transcript);
    println!("Proved encryption");

    println!("msg bits: {:?}", &msg_bits);
    println!("x_bp as int: {}", from_twos_complement_int(&msg_bits));

    let x_bp: [BulletproofsField; 15] = msg_bits
        .iter()
        .map(|x| BulletproofsField::from(*x as u64))
        .collect::<Vec<_>>()
        .try_into()
        .unwrap();
    let balance = BulletproofsField::from(12000u64);

    let transcript_sdlp = transcript.clone();

    let private_inputs_start: Vec<ZkpProgramInput> =
        vec![x_bp.into(), BulletproofsField::from(15u64).into()];
    let public_inputs_start: Vec<ZkpProgramInput> = vec![balance.into()];
    let constant_inputs_start: Vec<ZkpProgramInput> = vec![];

    let private_inputs = private_inputs_start
        .iter()
        .flat_map(|x| x.0.to_native_fields())
        .collect::<Vec<BigInt>>();
    let public_inputs = public_inputs_start
        .iter()
        .flat_map(|x| x.0.to_native_fields())
        .collect::<Vec<BigInt>>();
    let constant_inputs = constant_inputs_start
        .iter()
        .flat_map(|x| x.0.to_native_fields())
        .collect::<Vec<BigInt>>();

    let backend = BulletproofsBackend::new();
    let metrics = backend
        .metrics(
            valid_transaction_zkp,
            &private_inputs,
            &public_inputs,
            &constant_inputs,
        )
        .unwrap();

    let constraint_count = backend
        .constraint_count(
            valid_transaction_zkp,
            &private_inputs,
            &public_inputs,
            &constant_inputs,
        )
        .unwrap();

    let bulletproof_gens = BulletproofGens::new_single_party_with_shared_generators(
        2 * constraint_count,
        &shared_gens,
        metrics.multipliers - 1,
        metrics.pending_multiplier,
    );

    let verifier_parameters = BulletproofVerifierParameters::new(
        PedersenGens::default(),
        bulletproof_gens.clone(),
        shared_gens.len(),
    );

    let prover_parameters = BulletproofProverParameters::new(verifier_parameters.clone(), half_rho);

    let proof = runtime.prove_with_parameters::<ZkpProgramInput>(
        valid_transaction_zkp,
        private_inputs_start,
        public_inputs_start,
        constant_inputs_start,
        &prover_parameters,
        &mut transcript_sdlp.clone(),
    )?;

    println!("Proved ZKP with shared input");

    if let sunscreen::Proof::Bulletproofs(ref b) = proof {
        let b = b.clone();
        let a_i1_shared = (*b).0.A_I1_shared();

        if a_i1_shared != proof_sdlp.w_shared.compress() {
            println!("Shared commitments are not the same!!!!!!!!!!!!!!!!!!!!!!!1");
        } else {
            println!("Shared commitments in SDLP and R1CS BP are the same");
        }
    }

    // Verify the proof
    runtime.verify_with_parameters(
        valid_transaction_zkp,
        &proof,
        vec![balance],
        vec![],
        &verifier_parameters,
        &mut transcript_sdlp.clone(),
    )?;

    println!("Verified ZKP with shared input");

    println!("All proofs pass and are verified!");

    Ok(())
}
```