### PR TITLE
Generating SDLP for BFV statements

### DIFF
--- a/examples/calculator_fractional/src/main.rs
+++ b/examples/calculator_fractional/src/main.rs
@@ -121,7 +121,7 @@ fn encrypt_term(runtime: &FheRuntime, public_key: &PublicKey, input: Term) -> Te
         Term::Ans => Term::Ans,
         Term::F64(v) => Term::Encrypted(
             runtime
-                .encrypt(Fractional::<64>::try_from(v).unwrap(), public_key)
+                .encrypt(Fractional::<64>::from(v), public_key)
                 .unwrap(),
         ),
         _ => {
@@ -250,7 +250,7 @@ fn bob(
         let runtime = FheRuntime::new(app.params()).unwrap();
 
         let mut ans = runtime
-            .encrypt(Fractional::<64>::try_from(0f64).unwrap(), &public_key)
+            .encrypt(Fractional::<64>::from(0f64), &public_key)
             .unwrap();
 
         loop {

--- a/examples/mean_variance/src/main.rs
+++ b/examples/mean_variance/src/main.rs
@@ -149,7 +149,7 @@ impl Alice {
     pub fn encrypt_and_serialize_input(&self) -> Result<Vec<u8>, Error> {
         fn create_dataset() -> [Fractional<64>; DATA_POINTS] {
             (0..DATA_POINTS)
-                .map(|x| Fractional::try_from(x as f64).unwrap())
+                .map(|x| Fractional::from(x as f64))
                 .collect::<Vec<Fractional<64>>>()
                 .try_into()
                 .unwrap()

--- a/logproof/src/bfv_statement.rs
+++ b/logproof/src/bfv_statement.rs
@@ -20,12 +20,10 @@ use crate::{
 };
 
 /// In SEAL, `u` is sampled from a ternary distribution.
-// TODO if bounds are in u64 then perhaps this should be 3?
 const U_COEFFICIENT_BOUND: u64 = 2;
 /// In SEAL, `e` is sampled from a centered binomial distribution with std dev 3.2.
 const E_COEFFICIENT_BOUND: u64 = 16;
 /// In SEAL, secret keys are sampled from a ternary distribution.
-// TODO if bounds are in u64 then perhaps this should be 3?
 const S_COEFFICIENT_BOUND: u64 = 2;
 
 /// A proof statement verifying that a ciphertext is an encryption of a known plaintext message.

--- a/logproof/src/bfv_statement.rs
+++ b/logproof/src/bfv_statement.rs
@@ -21,8 +21,9 @@ use crate::{
 
 /// In SEAL, `u` is sampled from a ternary distribution.
 const U_COEFFICIENT_BOUND: u64 = 2;
-/// In SEAL, `e` is sampled from a centered binomial distribution with std dev 3.2.
-const E_COEFFICIENT_BOUND: u64 = 16;
+/// In SEAL, `e` is sampled from a centered binomial distribution with std dev 3.2, and a maximum
+/// width multiplier of 6, so max bound is 19.2.
+const E_COEFFICIENT_BOUND: u64 = 19;
 /// In SEAL, secret keys are sampled from a ternary distribution.
 const S_COEFFICIENT_BOUND: u64 = 2;
 

--- a/logproof/src/lib.rs
+++ b/logproof/src/lib.rs
@@ -52,7 +52,7 @@ pub use linear_relation::{
     VerifierKnowledge as LogProofVerifierKnowledge,
 };
 
-mod statement;
+pub mod bfv_statement;
 
 /**
  * A collection of fields Z_q you can use in our log proofs.

--- a/logproof/src/lib.rs
+++ b/logproof/src/lib.rs
@@ -52,6 +52,8 @@ pub use linear_relation::{
     VerifierKnowledge as LogProofVerifierKnowledge,
 };
 
+mod statement;
+
 /**
  * A collection of fields Z_q you can use in our log proofs.
  */

--- a/logproof/src/linear_algebra.rs
+++ b/logproof/src/linear_algebra.rs
@@ -824,7 +824,7 @@ mod tests {
             let mut coeffs = vec![];
 
             for j in 1..5 {
-                coeffs.push(ZqRistretto::try_from((i * j) as u64).unwrap());
+                coeffs.push(ZqRistretto::from((i * j) as u64));
             }
 
             polys.push(Polynomial { coeffs });
@@ -892,7 +892,7 @@ mod tests {
 
         for i in 0..a.rows {
             for j in 0..a.cols {
-                a[(i, j)] = ZqSeal128_8192::try_from((i + j) as u64).unwrap();
+                a[(i, j)] = ZqSeal128_8192::from((i + j) as u64);
             }
         }
 

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -77,28 +77,24 @@ impl std::ops::Deref for Bounds {
 }
 
 #[derive(Debug, Clone)]
-/**
- * The artifacts known to both the prover and verifier.
- */
+/// The artifacts known to both the prover and verifier.
 pub struct VerifierKnowledge<Q>
 where
     Q: Ring + CryptoHash + ModSwitch<ZqRistretto> + RingModulus<4> + Ord,
 {
-    /**
-     * The linear transform matrix A. `AS=T` should describe a series
-     * of RLWE/SIS instances (one per column of s and t) to ensure hardness
-     * in retrieving `S`.
-     */
+    /// The linear transform matrix A. `AS=T` should describe a series
+    /// of RLWE/SIS instances (one per column of s and t) to ensure hardness
+    /// in retrieving `S`.
     pub a: Matrix<Polynomial<Q>>,
 
-    /**
-     * The result of `AS`.
-     */
+    /// The result of `AS`.
     pub t: Matrix<Polynomial<Q>>,
 
-    /**
-     * A bound on each coefficient in the secret matrix S
-     */
+    /// A bound on each coefficient in the secret matrix S
+    ///
+    /// # Remarks
+    /// Every coefficient must have a bound, even if the polynomials have many leading zero
+    /// coefficients. Thus, each `Bound` should have length the degree of [`f`](`Self::f`).
     pub bounds: Matrix<Bounds>,
 
     /**

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -52,7 +52,7 @@ type MatrixPoly<Q> = Matrix<Polynomial<Q>>;
 /**
  * Bounds on the coefficients in the secret S
  */
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Bounds(pub Vec<u64>);
 
 impl Zero for Bounds {

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -90,10 +90,11 @@ where
     /// The result of `AS`.
     pub t: Matrix<Polynomial<Q>>,
 
-    /// A bound on each coefficient in the secret matrix S
+    /// A bound on each coefficient in the secret matrix S.
     ///
     /// Every coefficient must have a bound, even if the polynomials have many leading zero
     /// coefficients. Thus, each `Bound` should have length the degree of [`f`](`Self::f`).
+    /// Also, be aware that the bound is on the absolute value of the coefficient.
     pub bounds: Matrix<Bounds>,
 
     /// The ideal `f` that defines the quotient ring `Z_q[X]/f`.
@@ -158,7 +159,7 @@ where
         // the original paper we should get an undefined value. Here we say that
         // a zero bound produces a zero `b` value from the paper. This is later
         // used to ignore coefficients that have a bound of zero.
-        fn calculate_bound(v: &[u64]) -> Bounds {
+        fn calculate_bound(v: &Bounds) -> Bounds {
             Bounds(
                 v.iter()
                     .map(|b| if *b > 0 { Log2::ceil_log2(b) + 1 } else { 0 })
@@ -166,15 +167,7 @@ where
             )
         }
 
-        let mut new_matrix: Matrix<Bounds> = Matrix::new(self.bounds.rows, self.bounds.cols);
-
-        for i in 0..self.bounds.rows {
-            for j in 0..self.bounds.cols {
-                new_matrix[(i, j)] = calculate_bound(&self.bounds[(i, j)])
-            }
-        }
-
-        new_matrix
+        self.bounds.map(calculate_bound)
     }
 
     /**

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -1493,7 +1493,7 @@ mod test {
         let mut vals = vec![];
 
         for i in 0..257 {
-            let ring_val = Zr::try_from(i).unwrap();
+            let ring_val = Zr::from(i);
             vals.push(ring_val);
         }
 

--- a/logproof/src/linear_relation.rs
+++ b/logproof/src/linear_relation.rs
@@ -92,17 +92,13 @@ where
 
     /// A bound on each coefficient in the secret matrix S
     ///
-    /// # Remarks
     /// Every coefficient must have a bound, even if the polynomials have many leading zero
     /// coefficients. Thus, each `Bound` should have length the degree of [`f`](`Self::f`).
     pub bounds: Matrix<Bounds>,
 
-    /**
-     * The ideal `f` that defines the quotient ring `Z_q[X]/f`.
-     *
-     * # Remarks
-     * For FHE, this is usually `x^d+1` where `d` is a power of 2.
-     */
+    /// The ideal `f` that defines the quotient ring `Z_q[X]/f`.
+    ///
+    /// For FHE, this is usually `x^d+1` where `d` is a power of 2.
     pub f: Polynomial<Q>,
 }
 

--- a/logproof/src/statement.rs
+++ b/logproof/src/statement.rs
@@ -1,0 +1,710 @@
+// TODO revisit and see if there's a reasonable way to share code between BFV and TFHE logic. The
+// lower we go, the more it might be too much of a maintenance shackle than it is worth; at the
+// least, we could just have them impl the same high level traits, with impls not quite DRY.
+
+// The exported types here should be in terms of seal_fhe, with internal conversion logic to make
+// Prover/Verifier knowledge.
+
+use std::{borrow::Borrow, marker::PhantomData, ops::Neg};
+
+use crypto_bigint::{NonZero, Uint};
+use seal_fhe::{Ciphertext, Context, Modulus, Plaintext, PolynomialArray, PublicKey, SecretKey};
+use sunscreen_math::{
+    poly::Polynomial,
+    ring::{BarrettBackend, BarrettConfig, Ring, Zq},
+    One, Zero,
+};
+
+use crate::{
+    linear_algebra::PolynomialMatrix, rings::ZqRistretto, LogProofProverKnowledge,
+    LogProofVerifierKnowledge,
+};
+
+/// A proof statement verifying that a ciphertext is an encryption of a known plaintext message.
+/// Note that these statements are per SEAL plain/ciphertexts, where Sunscreen encodings are at a
+/// higher level. A single Sunscreen plaintext may actually encode multiple SEAL plaintexts, and
+/// hence multiple proof statements.
+//
+// Goddamn I miss higher kinded types :(
+pub enum BfvProofStatement<C, P> {
+    PrivateKeyEncryption {
+        message_id: usize,
+        ciphertext: C,
+    },
+    PublicKeyEncryption {
+        message_id: usize,
+        ciphertext: C,
+        public_key: P,
+    },
+}
+
+impl<C, P> BfvProofStatement<C, P> {
+    fn message_id(&self) -> usize {
+        match self {
+            BfvProofStatement::PrivateKeyEncryption { message_id, .. } => *message_id,
+            BfvProofStatement::PublicKeyEncryption { message_id, .. } => *message_id,
+        }
+    }
+
+    fn ciphertext(&self) -> &C {
+        match self {
+            BfvProofStatement::PrivateKeyEncryption { ciphertext, .. } => ciphertext,
+            BfvProofStatement::PublicKeyEncryption { ciphertext, .. } => ciphertext,
+        }
+    }
+
+    fn is_public(&self) -> bool {
+        matches!(self, BfvProofStatement::PublicKeyEncryption { .. })
+    }
+
+    fn is_private(&self) -> bool {
+        matches!(self, BfvProofStatement::PrivateKeyEncryption { .. })
+    }
+}
+
+/// A witness for a [`BfvProofStatement`].
+pub enum Witness<S> {
+    PrivateKeyEncryption {
+        /// The private key used for the encryption.
+        private_key: S,
+        /// Gaussian error polynomial
+        ///
+        /// N.B. this polynomial array should always have size one, see note below.
+        e: PolynomialArray,
+        /// Rounding component after scaling the message by delta.
+        r: Plaintext,
+    },
+    PublicKeyEncryption {
+        /// Uniform ternary polynomial.
+        ///
+        /// N.B. this polynomial array should always have size one, i.e. it is a single
+        /// polynomial. I believe the type is simply the only reasonable one exported by
+        /// `seal_fhe`.
+        u: PolynomialArray,
+        /// Gaussian error polynomial.
+        ///
+        /// Note that we currently assume that ciphertexts have length two, i.e.
+        /// relinearization happens after every multiplication, and hence this error
+        /// polynomial array should also have size two.
+        e: PolynomialArray,
+        /// Rounding component after scaling the message by delta.
+        r: Plaintext,
+    },
+}
+
+type Z<const N: usize, B> = Zq<N, BarrettBackend<N, B>>;
+
+/// Generate the full [`LogProofProverKnowledge`] for a given set of [`BfvProofStatement`]s. Some
+/// constraints to be aware of:
+///
+/// 1. We assume a common set of parameters is used across all statements.
+/// 2. Statements must reference message indices existing in the argument provided.
+/// 3. Witnesses must be provided in the same order as the statements to which they correspond.
+///
+/// The prover knowledge consists of a matrix triple `A, S, T` where `AS = T`. The verifier
+/// knowledge consists of just `A, T`. In the following description, we'll use "row" terminology
+/// referring to matrix `A`:
+///
+/// 1. Public key statements each take up two rows.
+/// 2. Private key statements each take up one row.
+/// 3. The offsets occur in blocks for each variable in the encryption statement; that is, given
+///    that `c[0] = d * m + r + u * p[0] + e[0]` and `c[1] = u * p[1] + e[1]` for a public key
+///    encryption and `c[0] = d * m + r - (u * s + e)` and `c[1] = u` for a private key encryption,
+///    the offsets are ordered in blocks `d, r, pk, e[0], e[1], sk, e`, with the size of each block
+///    depending on the number of messages, statements, and public vs. private statements. This is
+///    almost impossible to express via text, but should be easy to follow in the example below.
+///
+/// For example, if we have two public key statements and one private key statement for three
+/// separate messages:
+/// ```ignore
+///                         A                     *   S        =     T
+/// (    d     r         pk     e[0] e[1] s   e )
+/// [ [d 0 0 1 0 0 p_1[0] 0      1 0 0 0  0   0 ]   [   m_1  ]   [ c_1[0] ]
+/// [ [0 0 0 0 0 0 p_1[1] 0      0 0 1 0  0   0 ]   [   m_2  ]   [ c_1[1] ]
+/// [ [0 d 0 0 1 0 0      p_2[0] 0 1 0 0  0   0 ] * [   m_3  ] = [ c_2[0] ]
+/// [ [0 0 0 0 0 0 0      p_2[1] 0 0 0 1  0   0 ]   [   r_1  ]   [ c_2[1] ]
+/// [ [0 0 d 0 0 1 0      0      0 0 0 0  u_3 1 ]   [   r_2  ]   [ c_3[0] ]
+///                                                 [   r_3  ]
+///                                                 [   u_1  ]
+///                                                 [   u_2  ]
+///                                                 [ e_1[0] ]
+///                                                 [ e_2[0] ]
+///                                                 [ e_1[1] ]
+///                                                 [ e_2[1] ]
+///                                                 [   -s   ]
+///                                                 [  -e_3  ]
+/// ```
+///
+/// If the private key statement is also encrypting the first message, this can be compacted:
+/// ```ignore
+///                     A                       *   S        =     T
+/// (    d   r         pk     e[0] e[1] s   e )
+/// [ [d 0 1 0 0 p_1[0] 0      1 0 0 0  0   0 ]   [   m_1  ]   [ c_1[0] ]
+/// [ [0 0 0 0 0 p_1[1] 0      0 0 1 0  0   0 ]   [   m_2  ]   [ c_1[1] ]
+/// [ [0 d 0 1 0 0      p_2[0] 0 1 0 0  0   0 ] * [   r_1  ] = [ c_2[0] ]
+/// [ [0 0 0 0 0 0      p_2[1] 0 0 0 1  0   0 ]   [   r_2  ]   [ c_2[1] ]
+/// [ [d 0 0 0 1 0      0      0 0 0 0  u_3 1 ]   [   r_3  ]   [ c_3[0] ]
+///                                               [   u_1  ]
+///                                               [   u_2  ]
+///                                               [ e_1[0] ]
+///                                               [ e_2[0] ]
+///                                               [ e_1[1] ]
+///                                               [ e_2[1] ]
+///                                               [   -s   ]
+///                                               [  -e_3  ]
+///
+/// ```
+///
+/// Note that the remainder for a given (plaintext, plaintext modulus, ciphertext modulus) trio
+/// should be constant, and thus it should technically be possible to reuse the remainder for
+/// multiple encryptions (public or private) of a single plaintext message, like we do for the
+/// delta scaling parameter. However, since the remainder is held in each [`Witness`], I've gone
+/// with the less surprising implementation where we have a remainder witness for each statement.
+pub fn generate_prover_knowledge<C, P, S, D, B, const N: usize>(
+    statements: &[BfvProofStatement<C, P>],
+    messages: &[Plaintext], // may want messages AsRef as well.. we'll see
+    witness: &[Witness<S>],
+    params: D,
+    ctx: &Context,
+) -> LogProofProverKnowledge<Z<N, B>>
+where
+    B: BarrettConfig<N>,
+    C: Borrow<Ciphertext>,
+    P: Borrow<PublicKey>,
+    D: AsDelta<N, B>,
+    S: Borrow<SecretKey>,
+{
+    let vk = generate_verifier_knowledge(statements, params, ctx);
+
+    let s = compute_s(statements, messages, witness);
+
+    LogProofProverKnowledge { vk, s }
+}
+
+pub fn generate_verifier_knowledge<C, P, D, B, const N: usize>(
+    statements: &[BfvProofStatement<C, P>],
+    params: D,
+    ctx: &Context,
+) -> LogProofVerifierKnowledge<Z<N, B>>
+where
+    B: BarrettConfig<N>,
+    C: Borrow<Ciphertext>,
+    P: Borrow<PublicKey>,
+    D: AsDelta<N, B>,
+{
+    let a = compute_a(statements, params, ctx);
+    let t = compute_t(statements, ctx);
+
+    LogProofVerifierKnowledge {
+        a,
+        t,
+        bounds: todo!(),
+        f: todo!(),
+    }
+}
+
+fn compute_a<C, P, D, B, const N: usize>(
+    statements: &[BfvProofStatement<C, P>],
+    params: D,
+    ctx: &Context,
+) -> PolynomialMatrix<Z<N, B>>
+where
+    B: BarrettConfig<N>,
+    C: Borrow<Ciphertext>,
+    P: Borrow<PublicKey>,
+    D: AsDelta<N, B>,
+{
+    let mut offsets = IdxOffsets::new(statements);
+    let (rows, cols) = offsets.a_shape();
+    let mut a = PolynomialMatrix::new(rows, cols);
+
+    let d = Polynomial {
+        coeffs: vec![params.as_delta()],
+    };
+
+    let mut row = 0;
+    for s in statements {
+        // m*d block
+        let msg_idx = s.message_id();
+        debug_assert_eq!(a[(row, msg_idx)], Polynomial::zero());
+        a[(row, msg_idx)] = d.clone();
+
+        // r block
+        debug_assert_eq!(a[(row, offsets.remainder)], Polynomial::zero());
+        a[(row, offsets.remainder)] = Polynomial::one();
+
+        match s {
+            // s, e blocks
+            BfvProofStatement::PrivateKeyEncryption { ciphertext, .. } => {
+                let u = (ctx, ciphertext.borrow()).as_poly_vec().pop().unwrap();
+                debug_assert_eq!(a[(row, offsets.private_u)], Polynomial::zero());
+                debug_assert_eq!(a[(row, offsets.private_e)], Polynomial::zero());
+                a[(row, offsets.private_u)] = u;
+                a[(row, offsets.private_e)] = Polynomial::one();
+                offsets.inc_private();
+
+                row += 1;
+            }
+            // pk, e0, e1 blocks
+            BfvProofStatement::PublicKeyEncryption { public_key, .. } => {
+                let mut pk = (ctx, public_key.borrow()).as_poly_vec();
+                let p1 = pk.pop().unwrap();
+                let p0 = pk.pop().unwrap();
+                debug_assert_eq!(a[(row, offsets.public_key)], Polynomial::zero());
+                debug_assert_eq!(a[(row + 1, offsets.public_key)], Polynomial::zero());
+                debug_assert_eq!(a[(row, offsets.public_e_0)], Polynomial::zero());
+                debug_assert_eq!(a[(row + 1, offsets.public_e_1)], Polynomial::zero());
+                a[(row, offsets.public_key)] = p0;
+                a[(row + 1, offsets.public_key)] = p1;
+                a[(row, offsets.public_e_0)] = Polynomial::one();
+                a[(row + 1, offsets.public_e_1)] = Polynomial::one();
+                offsets.inc_public();
+
+                row += 2;
+            }
+        }
+    }
+
+    a
+}
+
+fn compute_s<C, P, S, B, const N: usize>(
+    statements: &[BfvProofStatement<C, P>],
+    messages: &[Plaintext],
+    witness: &[Witness<S>],
+) -> PolynomialMatrix<Z<N, B>>
+where
+    B: BarrettConfig<N>,
+    C: Borrow<Ciphertext>,
+    P: Borrow<PublicKey>,
+    S: Borrow<SecretKey>,
+{
+    let mut offsets = IdxOffsets::new(statements);
+    let mut s = PolynomialMatrix::new(offsets.a_shape().1, 1);
+
+    // m_i block
+    for (i, m) in messages.iter().enumerate() {
+        debug_assert_eq!(s[(i, 0)], Polynomial::zero());
+        s[(i, 0)] = m.as_poly();
+    }
+
+    // r_i, u_i, e_i, s, e blocks
+    for w in witness {
+        match w {
+            // s, e
+            Witness::PrivateKeyEncryption { private_key, e, r } => {
+                let r = r.as_poly();
+                let sk = private_key.borrow().as_poly();
+                let e = e.as_poly_vec().pop().unwrap();
+                debug_assert_eq!(s[(offsets.remainder, 0)], Polynomial::zero());
+                debug_assert_eq!(s[(offsets.private_u, 0)], Polynomial::zero());
+                debug_assert_eq!(s[(offsets.private_e, 0)], Polynomial::zero());
+                s[(offsets.remainder, 0)] = r;
+                s[(offsets.private_u, 0)] = sk.neg();
+                s[(offsets.private_e, 0)] = e.neg();
+                offsets.inc_private();
+            }
+            // r_i, u_i, e_i
+            Witness::PublicKeyEncryption { u, e, r } => {
+                let r = r.as_poly();
+                let u = u.as_poly_vec().pop().unwrap();
+                let mut e = e.as_poly_vec();
+                debug_assert_eq!(e.len(), 2, "ciphertexts must have length two");
+                let e1 = e.pop().unwrap();
+                let e0 = e.pop().unwrap();
+                debug_assert_eq!(s[(offsets.remainder, 0)], Polynomial::zero());
+                debug_assert_eq!(s[(offsets.public_key, 0)], Polynomial::zero());
+                debug_assert_eq!(s[(offsets.public_e_0, 0)], Polynomial::zero());
+                debug_assert_eq!(s[(offsets.public_e_1, 0)], Polynomial::zero());
+                s[(offsets.remainder, 0)] = r;
+                s[(offsets.public_key, 0)] = u;
+                s[(offsets.public_e_0, 0)] = e0;
+                s[(offsets.public_e_1, 0)] = e1;
+                offsets.inc_public();
+            }
+        }
+    }
+
+    s
+}
+
+fn compute_t<C, P, B, const N: usize>(
+    statements: &[BfvProofStatement<C, P>],
+    ctx: &Context,
+) -> PolynomialMatrix<Z<N, B>>
+where
+    B: BarrettConfig<N>,
+    C: Borrow<Ciphertext>,
+    P: Borrow<PublicKey>,
+{
+    let rows = statements
+        .iter()
+        .flat_map(|s| {
+            let mut c = (ctx, s.ciphertext().borrow()).as_poly_vec();
+            // only include first ciphertext element for private statements
+            if s.is_private() {
+                c.pop().unwrap();
+            }
+            c
+        })
+        .collect::<Vec<_>>();
+    let t = PolynomialMatrix::from(rows);
+
+    let offsets = IdxOffsets::new(statements);
+    debug_assert_eq!(t.rows, offsets.a_shape().0);
+    debug_assert_eq!(t.cols, 1);
+
+    t
+}
+
+/// Represents the column offsets in `A` and the row offsets in `S` for the various fields.
+struct IdxOffsets<C, P> {
+    /// The remainder block occurs after the delta/message block.
+    remainder: usize,
+    /// The public key block occurs after the remainders.
+    public_key: usize,
+    /// The public key statement's first error component block occurs after the public keys.
+    public_e_0: usize,
+    /// The public key statement's second error component block occurs after the first.
+    public_e_1: usize,
+    /// The private key block occurs next.
+    private_u: usize,
+    /// The private key statement's error component block occurs last.
+    private_e: usize,
+    _phantom: PhantomData<(C, P)>,
+}
+
+impl<C, P> IdxOffsets<C, P> {
+    fn new(statements: &[BfvProofStatement<C, P>]) -> Self {
+        // Counts
+        let num_messages = Self::num_messages(statements);
+        let num_public = Self::num_public(statements);
+        let num_private = Self::num_private(statements);
+        let num_statements = statements.len();
+
+        // Offsets
+        let remainder = num_messages;
+        let public_key = remainder + num_statements;
+        let public_e_0 = public_key + num_public;
+        let public_e_1 = public_e_0 + num_public;
+        let private_u = public_e_1 + num_public;
+        let private_e = private_u + num_private;
+
+        Self {
+            remainder,
+            public_key,
+            public_e_0,
+            public_e_1,
+            private_u,
+            private_e,
+            _phantom: PhantomData,
+        }
+    }
+
+    /// Return the (row, col) shape of A.
+    fn a_shape(&self) -> (usize, usize) {
+        let num_private = self.private_e - self.private_u;
+        let num_public = self.public_e_0 - self.public_key;
+        (self.private_e + num_private, num_public * 2 + num_private)
+    }
+
+    /// Record that a private statement or witness has been inserted into `A` or `S`, respectively
+    /// bumping the indices.
+    fn inc_private(&mut self) {
+        self.remainder += 1;
+        self.private_u += 1;
+        self.private_e += 1;
+    }
+
+    /// Record that a public statement or witness has been inserted into `A` or `S`, respectively
+    /// bumping the indices.
+    fn inc_public(&mut self) {
+        self.remainder += 1;
+        self.public_key += 1;
+        self.public_e_0 += 1;
+        self.public_e_1 += 1;
+    }
+
+    fn num_messages(statements: &[BfvProofStatement<C, P>]) -> usize {
+        statements
+            .iter()
+            .fold(0usize, |max, s| usize::max(max, s.message_id()))
+            + 1
+    }
+
+    fn num_private(statements: &[BfvProofStatement<C, P>]) -> usize {
+        statements.iter().filter(|s| s.is_private()).count()
+    }
+
+    fn num_public(statements: &[BfvProofStatement<C, P>]) -> usize {
+        statements.len() - Self::num_private(statements)
+    }
+}
+
+trait AsPolynomial<R: Ring> {
+    fn as_poly(&self) -> Polynomial<R>;
+}
+
+trait AsPolynomials<R: Ring> {
+    fn as_poly_vec(&self) -> Vec<Polynomial<R>>;
+}
+
+impl<const N: usize, B: BarrettConfig<N>> AsPolynomial<Z<N, B>> for Plaintext {
+    fn as_poly(&self) -> Polynomial<Z<N, B>> {
+        Polynomial {
+            coeffs: strip_trailing_value(
+                (0..self.len())
+                    .map(|i| Zq::from(self.get_coefficient(i)))
+                    .collect::<Vec<_>>(),
+                Zq::zero(),
+            ),
+        }
+    }
+}
+
+impl<const N: usize, B: BarrettConfig<N>> AsPolynomial<Z<N, B>> for SecretKey {
+    fn as_poly(&self) -> Polynomial<Z<N, B>> {
+        todo!()
+    }
+}
+
+impl<const N: usize, B: BarrettConfig<N>> AsPolynomials<Z<N, B>> for PolynomialArray {
+    fn as_poly_vec(&self) -> Vec<Polynomial<Z<N, B>>> {
+        let chunk_size = self.coeff_modulus_size() as usize;
+
+        let bigint_values = self
+            .as_multiprecision_u64s()
+            .unwrap()
+            .chunks(chunk_size)
+            // SEAL sometimes encodes a multiprecision integer with more limbs
+            // than needed. The trailing limbs can be safely removed since they
+            // are 0.
+            .map(|x| Uint::<N>::from_words(x[0..N].try_into().unwrap()))
+            .collect::<Vec<_>>();
+
+        bigint_values
+            .chunks(self.poly_modulus_degree() as usize)
+            .map(|x| {
+                let leading_zeros_removed = strip_trailing_value(x.to_vec(), Uint::<N>::ZERO);
+                Polynomial {
+                    coeffs: leading_zeros_removed
+                        .iter()
+                        .map(|y| Zq::try_from(*y).unwrap())
+                        .collect::<Vec<_>>(),
+                }
+            })
+            .collect()
+    }
+}
+
+impl<const N: usize, B: BarrettConfig<N>> AsPolynomials<Z<N, B>> for (&Context, &Ciphertext) {
+    fn as_poly_vec(&self) -> Vec<Polynomial<Z<N, B>>> {
+        let poly_array = PolynomialArray::new_from_ciphertext(self.0, self.1).unwrap();
+        poly_array.as_poly_vec()
+    }
+}
+
+impl<const N: usize, B: BarrettConfig<N>> AsPolynomials<Z<N, B>> for (&Context, &PublicKey) {
+    fn as_poly_vec(&self) -> Vec<Polynomial<Z<N, B>>> {
+        let poly_array = PolynomialArray::new_from_public_key(self.0, self.1).unwrap();
+        poly_array.as_poly_vec()
+    }
+}
+
+/// A generic way to pass in the necessary BFV parameters (i.e. the plain & coeff moduli).
+pub trait AsDelta<const N: usize, B: BarrettConfig<N>> {
+    fn as_delta(&self) -> Z<N, B>;
+}
+
+impl<const N: usize, B: BarrettConfig<N>> AsDelta<N, B> for (Modulus, Vec<Modulus>) {
+    fn as_delta(&self) -> Z<N, B> {
+        let (p, qs) = self;
+        (p.value(), qs.iter().map(|q| q.value()).collect()).as_delta()
+    }
+}
+
+impl<const N: usize, B: BarrettConfig<N>> AsDelta<N, B> for (u64, Vec<u64>) {
+    fn as_delta(&self) -> Z<N, B> {
+        let (p, qs) = self;
+
+        // Calculate the data coefficient modulus, which for fields with more
+        // that one modulus in the coefficient modulus set is equal to the
+        // product of all but the last moduli in the set.
+        let mut data_modulus = ZqRistretto::from(1);
+        if qs.len() == 1 {
+            data_modulus = data_modulus * ZqRistretto::from(qs[0]);
+        } else {
+            for q in qs.iter().take(qs.len() - 1) {
+                data_modulus = data_modulus * ZqRistretto::from(*q);
+            }
+        }
+        let p_bigint = NonZero::new(Uint::from(*p)).unwrap();
+        let delta = data_modulus.into_bigint().div_rem(&p_bigint).0;
+        let limbs = delta.as_limbs().map(|l| l.into());
+        let delta_uint = Uint::<N>::from_words(limbs[0..N].try_into().unwrap());
+        Zq::try_from(delta_uint).unwrap()
+    }
+}
+
+fn strip_trailing_value<T>(mut v: Vec<T>, trim_value: T) -> Vec<T>
+where
+    T: Eq,
+{
+    while v.last().map_or(false, |c| *c == trim_value) {
+        v.pop();
+    }
+
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::seq::IteratorRandom;
+    use seal_fhe::{
+        BFVScalarEncoder, BfvEncryptionParametersBuilder, CoefficientModulus, Context, Decryptor,
+        Encryptor, KeyGenerator, PlainModulus, SecurityLevel,
+    };
+
+    use crate::rings::{SealQ128_1024, ZqSeal128_1024, ZqSeal128_4096};
+
+    use super::*;
+
+    #[test]
+    fn test_idx_offsets() {
+        // recreating the example in the docs
+        let statements = vec![
+            BfvProofStatement::PublicKeyEncryption {
+                message_id: 0,
+                ciphertext: 0xdeadbeef_u32,
+                public_key: 100_u32,
+            },
+            BfvProofStatement::PublicKeyEncryption {
+                message_id: 1,
+                ciphertext: 0xdeedbeaf_u32,
+                public_key: 100_u32,
+            },
+            BfvProofStatement::PrivateKeyEncryption {
+                message_id: 0,
+                ciphertext: 0xbeefdead_u32,
+            },
+        ];
+
+        let idx_offsets = IdxOffsets::new(&statements);
+
+        assert_eq!(idx_offsets.remainder, 2);
+        assert_eq!(idx_offsets.public_key, 2 + 3);
+        assert_eq!(idx_offsets.public_e_0, 2 + 3 + 2);
+        assert_eq!(idx_offsets.public_e_1, 2 + 3 + 2 + 2);
+        assert_eq!(idx_offsets.private_u, 2 + 3 + 2 + 2 + 2);
+        assert_eq!(idx_offsets.private_e, 2 + 3 + 2 + 2 + 2 + 1);
+    }
+
+    #[test]
+    fn test_delta() {
+        let moduli = (3, vec![11]);
+        let delta: ZqSeal128_1024 = moduli.as_delta();
+        assert_eq!(delta.val.as_words()[0], 11 / 3);
+
+        let moduli = (4, vec![11, 13]);
+        let delta: ZqSeal128_4096 = moduli.as_delta();
+        assert_eq!(delta.val.as_words()[0], 11 * 13 / 4);
+    }
+
+    struct TestFixture {
+        statements: Vec<BfvProofStatement<Ciphertext, PublicKey>>,
+        messages: Vec<Plaintext>,
+        witness: Vec<Witness<SecretKey>>,
+    }
+
+    struct BFVTestContext {
+        ctx: Context,
+        public_key: PublicKey,
+        secret_key: SecretKey,
+        encryptor: Encryptor,
+        decryptor: Decryptor,
+        encoder: BFVScalarEncoder,
+    }
+
+    impl TestFixture {
+        // TODO add private statements once we have a way to generate them
+        fn random() -> Self {
+            let ctx = BFVTestContext::new();
+            let mut rng = rand::thread_rng();
+
+            let statement_count = (1..=10).choose(&mut rng).unwrap();
+            let duplicate_msg_count = (0..statement_count).choose(&mut rng).unwrap();
+            let msg_count = statement_count - duplicate_msg_count;
+
+            // all the messages
+            let messages = (0..msg_count)
+                .map(|_| ctx.encoder.encode_unsigned(rand::random()).unwrap())
+                .collect::<Vec<_>>();
+
+            let mut statements = Vec::with_capacity(statement_count);
+            let mut witness = Vec::with_capacity(statement_count);
+
+            // statements without duplicate messages
+            for (i, msg) in messages.iter().enumerate() {
+                let (ct, u, e, r) = ctx.encryptor.encrypt_return_components(msg).unwrap();
+                statements.push(BfvProofStatement::PublicKeyEncryption {
+                    message_id: i,
+                    ciphertext: ct,
+                    public_key: ctx.public_key.clone(),
+                });
+                witness.push(Witness::PublicKeyEncryption { u, e, r });
+            }
+
+            // add in the statements about existing messages
+            for _ in 0..duplicate_msg_count {
+                let i = (0..msg_count).choose(&mut rng).unwrap();
+                let (ct, u, e, r) = ctx
+                    .encryptor
+                    .encrypt_return_components(&messages[i])
+                    .unwrap();
+                statements.push(BfvProofStatement::PublicKeyEncryption {
+                    message_id: i,
+                    ciphertext: ct,
+                    public_key: ctx.public_key.clone(),
+                });
+                witness.push(Witness::PublicKeyEncryption { u, e, r });
+            }
+
+            Self {
+                statements,
+                messages,
+                witness,
+            }
+        }
+    }
+
+    impl BFVTestContext {
+        fn new() -> Self {
+            let plain_modulus = PlainModulus::raw(1153).unwrap();
+            let coeff_modulus =
+                CoefficientModulus::bfv_default(1024, SecurityLevel::TC128).unwrap();
+            let params = BfvEncryptionParametersBuilder::new()
+                .set_poly_modulus_degree(1024)
+                .set_coefficient_modulus(coeff_modulus)
+                .set_plain_modulus(plain_modulus)
+                .build()
+                .unwrap();
+            let ctx = Context::new(&params, false, SecurityLevel::TC128).unwrap();
+            let gen = KeyGenerator::new(&ctx).unwrap();
+            let public_key = gen.create_public_key();
+            let secret_key = gen.secret_key();
+            let encryptor =
+                Encryptor::with_public_and_secret_key(&ctx, &public_key, &secret_key).unwrap();
+            let decryptor = Decryptor::new(&ctx, &secret_key).unwrap();
+            let encoder = BFVScalarEncoder::new();
+
+            BFVTestContext {
+                ctx,
+                public_key,
+                secret_key,
+                encryptor,
+                decryptor,
+                encoder,
+            }
+        }
+    }
+}

--- a/seal_fhe/src/key_generator.rs
+++ b/seal_fhe/src/key_generator.rs
@@ -192,6 +192,7 @@ impl Drop for KeyGenerator {
 /**
  * Class to store a public key.
  */
+#[derive(Debug)]
 pub struct PublicKey {
     handle: *mut c_void,
 }
@@ -285,6 +286,12 @@ impl Clone for PublicKey {
             .expect("Fatal error in PublicKey::clone");
 
         Self { handle }
+    }
+}
+
+impl AsRef<PublicKey> for PublicKey {
+    fn as_ref(&self) -> &PublicKey {
+        self
     }
 }
 
@@ -415,6 +422,20 @@ impl Clone for SecretKey {
             .expect("Fatal error in SecretKey::clone");
 
         Self { handle }
+    }
+}
+
+impl core::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
+        f.debug_struct("SecretKey")
+            .field("handle", &"<ELIDED>")
+            .finish()
+    }
+}
+
+impl AsRef<SecretKey> for SecretKey {
+    fn as_ref(&self) -> &SecretKey {
+        self
     }
 }
 

--- a/seal_fhe/src/plaintext_ciphertext.rs
+++ b/seal_fhe/src/plaintext_ciphertext.rs
@@ -51,6 +51,12 @@ impl Clone for Plaintext {
     }
 }
 
+impl AsRef<Plaintext> for Plaintext {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+
 impl PartialEq for Plaintext {
     fn eq(&self, other: &Self) -> bool {
         if self.len() == other.len() {
@@ -161,7 +167,7 @@ impl Plaintext {
     }
 
     /**
-     * Constructs an empty ciphertext allocating no memory.
+     * Constructs an empty plaintext allocating no memory.
      */
     pub fn new() -> Result<Self> {
         let mut handle: *mut c_void = null_mut();
@@ -316,6 +322,7 @@ impl Drop for Plaintext {
  * constructor as an extra argument, or by calling the reserve function at
  * any time.
  */
+#[derive(Debug)]
 pub struct Ciphertext {
     handle: *mut c_void,
 }
@@ -331,6 +338,12 @@ impl Clone for Ciphertext {
             .expect("Fatal error: Failed to clone ciphertext");
 
         Self { handle }
+    }
+}
+
+impl AsRef<Ciphertext> for Ciphertext {
+    fn as_ref(&self) -> &Self {
+        self
     }
 }
 

--- a/sunscreen/src/types/bfv/batched.rs
+++ b/sunscreen/src/types/bfv/batched.rs
@@ -676,52 +676,52 @@ mod tests {
 
     #[test]
     fn can_add_non_fhe() {
-        let a = Batched::<4>::try_from(A_VEC).unwrap();
-        let b = Batched::<4>::try_from(B_VEC).unwrap();
+        let a = Batched::<4>::from(A_VEC);
+        let b = Batched::<4>::from(B_VEC);
 
         assert_eq!(a + b, [[6, 8, 10, 12], [6, 8, 10, 12]].into());
     }
 
     #[test]
     fn can_mul_non_fhe() {
-        let a = Batched::<4>::try_from(A_VEC).unwrap();
-        let b = Batched::<4>::try_from(B_VEC).unwrap();
+        let a = Batched::<4>::from(A_VEC);
+        let b = Batched::<4>::from(B_VEC);
 
         assert_eq!(a * b, [[5, 12, 21, 32], [5, 12, 21, 32]].into());
     }
 
     #[test]
     fn can_sub_non_fhe() {
-        let a = Batched::<4>::try_from(A_VEC).unwrap();
-        let b = Batched::<4>::try_from(B_VEC).unwrap();
+        let a = Batched::<4>::from(A_VEC);
+        let b = Batched::<4>::from(B_VEC);
 
         assert_eq!(a - b, [[-4, -4, -4, -4], [4, 4, 4, 4]].into());
     }
 
     #[test]
     fn can_neg_non_fhe() {
-        let a = Batched::<4>::try_from(A_VEC).unwrap();
+        let a = Batched::<4>::from(A_VEC);
 
         assert_eq!(-a, [[-1, -2, -3, -4], [-5, -6, -7, -8]].into());
     }
 
     #[test]
     fn can_shl_non_fhe() {
-        let a = Batched::<4>::try_from(A_VEC).unwrap();
+        let a = Batched::<4>::from(A_VEC);
 
         assert_eq!(a << 3, [[4, 1, 2, 3], [8, 5, 6, 7]].into());
     }
 
     #[test]
     fn can_shr_non_fhe() {
-        let a = Batched::<4>::try_from(A_VEC).unwrap();
+        let a = Batched::<4>::from(A_VEC);
 
         assert_eq!(a >> 3, [[2, 3, 4, 1], [6, 7, 8, 5]].into());
     }
 
     #[test]
     fn can_swap_rows_non_fhe() {
-        let a = Batched::<4>::try_from(A_VEC).unwrap();
+        let a = Batched::<4>::from(A_VEC);
 
         assert_eq!(a.swap_rows(), [[5, 6, 7, 8], [1, 2, 3, 4]].into());
     }

--- a/sunscreen/tests/array.rs
+++ b/sunscreen/tests/array.rs
@@ -32,8 +32,8 @@ fn can_add_array_elements() {
 
     let (public_key, private_key) = runtime.generate_keys().unwrap();
 
-    let a = Signed::try_from(2).unwrap();
-    let b = Signed::try_from(4).unwrap();
+    let a = Signed::from(2);
+    let b = Signed::from(4);
     let a_c = runtime.encrypt([a, b], &public_key).unwrap();
 
     let result = runtime

--- a/sunscreen/tests/fractional.rs
+++ b/sunscreen/tests/fractional.rs
@@ -61,9 +61,9 @@ fn can_add() {
     let (public_key, private_key) = runtime.generate_keys().unwrap();
 
     let do_add = |a: f64, b: f64| {
-        let a_p = Fractional::<64>::try_from(a).unwrap();
+        let a_p = Fractional::<64>::from(a);
         let a_c = runtime.encrypt(a_p, &public_key).unwrap();
-        let b_p = Fractional::<64>::try_from(b).unwrap();
+        let b_p = Fractional::<64>::from(b);
         let b_c = runtime.encrypt(b_p, &public_key).unwrap();
 
         let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_c.clone().into()];
@@ -167,9 +167,9 @@ fn can_mul() {
     let (public_key, private_key) = runtime.generate_keys().unwrap();
 
     let do_mul = |a: f64, b: f64| {
-        let a_p = Fractional::<64>::try_from(a).unwrap();
+        let a_p = Fractional::<64>::from(a);
         let a_c = runtime.encrypt(a_p, &public_key).unwrap();
-        let b_p = Fractional::<64>::try_from(b).unwrap();
+        let b_p = Fractional::<64>::from(b);
         let b_c = runtime.encrypt(b_p, &public_key).unwrap();
 
         let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_c.clone().into()];
@@ -293,9 +293,9 @@ fn can_sub() {
     let (public_key, private_key) = runtime.generate_keys().unwrap();
 
     let do_sub = |a: f64, b: f64| {
-        let a_p = Fractional::<64>::try_from(a).unwrap();
+        let a_p = Fractional::<64>::from(a);
         let a_c = runtime.encrypt(a_p, &public_key).unwrap();
-        let b_p = Fractional::<64>::try_from(b).unwrap();
+        let b_p = Fractional::<64>::from(b);
         let b_c = runtime.encrypt(b_p, &public_key).unwrap();
 
         let args: Vec<FheProgramInput> = vec![a_c.clone().into(), b_c.clone().into()];
@@ -369,7 +369,7 @@ fn can_div_cipher_const() {
 
     let test_div = |a: f64| {
         let a_c = runtime
-            .encrypt(Fractional::<64>::try_from(a).unwrap(), &public_key)
+            .encrypt(Fractional::<64>::from(a), &public_key)
             .unwrap();
 
         let args: Vec<FheProgramInput> = vec![a_c.into()];
@@ -413,7 +413,7 @@ fn can_negate() {
 
     let test_div = |a: f64| {
         let a_c = runtime
-            .encrypt(Fractional::<64>::try_from(a).unwrap(), &public_key)
+            .encrypt(Fractional::<64>::from(a), &public_key)
             .unwrap();
 
         let args: Vec<FheProgramInput> = vec![a_c.into()];

--- a/sunscreen/tests/linked.rs
+++ b/sunscreen/tests/linked.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "linkedproofs")]
 mod linked_tests {
     use logproof::test::seal_bfv_encryption_linear_relation;
+    use sunscreen::types::zkp::BulletproofsField;
     use sunscreen::Error;
     use sunscreen::{
         types::zkp::{ConstrainCmp, Field, FieldSpec, ProgramNode},
@@ -10,12 +11,6 @@ mod linked_tests {
 
     use logproof::rings::SealQ128_1024;
     use sunscreen_zkp_backend::bulletproofs::BulletproofsBackend;
-
-    // We copy the sunscreen_zkp_backend::bulletproofs::BulletproofsField type here
-    // because we can't import it directly from sunscreen_zkp_backend without
-    // enabling the "bulletproofs" feature
-    type BulletproofsField =
-    Field<<sunscreen_zkp_backend::bulletproofs::BulletproofsBackend as sunscreen_zkp_backend::ZkpBackend>::Field>;
 
     /// Convert a twos complement represented signed integer into a field element.
     fn from_twos_complement_field_element<F: FieldSpec, const N: usize>(

--- a/sunscreen_math/src/poly/mod.rs
+++ b/sunscreen_math/src/poly/mod.rs
@@ -391,7 +391,7 @@ mod tests {
         type TestPoly = Polynomial<Zq<1, BarrettBackend<1, Cfg>>>;
 
         let x = TestPoly {
-            coeffs: vec![R::try_from(1).unwrap()],
+            coeffs: vec![R::from(1)],
         };
 
         assert_eq!(x.vartime_degree(), 0);
@@ -407,12 +407,7 @@ mod tests {
         type TestPoly = Polynomial<Zq<1, BarrettBackend<1, Cfg>>>;
 
         let x = TestPoly {
-            coeffs: vec![
-                R::try_from(0).unwrap(),
-                R::try_from(1).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(3).unwrap(),
-            ],
+            coeffs: vec![R::from(0), R::from(1), R::from(2), R::from(3)],
         };
 
         assert_eq!(x.vartime_degree(), 3);
@@ -428,13 +423,7 @@ mod tests {
         type TestPoly = Polynomial<Zq<1, BarrettBackend<1, Cfg>>>;
 
         let x = TestPoly {
-            coeffs: vec![
-                R::try_from(0).unwrap(),
-                R::try_from(1).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(3).unwrap(),
-                R::try_from(0).unwrap(),
-            ],
+            coeffs: vec![R::from(0), R::from(1), R::from(2), R::from(3), R::from(0)],
         };
 
         assert_eq!(x.vartime_degree(), 3);
@@ -483,28 +472,15 @@ mod tests {
         assert_eq!(TestPoly::zero(), TestPoly::zero());
 
         let a = TestPoly {
-            coeffs: vec![
-                R::try_from(0).unwrap(),
-                R::try_from(1).unwrap(),
-                R::try_from(2).unwrap(),
-            ],
+            coeffs: vec![R::from(0), R::from(1), R::from(2)],
         };
 
         let b = TestPoly {
-            coeffs: vec![
-                R::try_from(1).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(3).unwrap(),
-            ],
+            coeffs: vec![R::from(1), R::from(2), R::from(3)],
         };
 
         let c = TestPoly {
-            coeffs: vec![
-                R::try_from(0).unwrap(),
-                R::try_from(1).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(3).unwrap(),
-            ],
+            coeffs: vec![R::from(0), R::from(1), R::from(2), R::from(3)],
         };
 
         assert_eq!(a, a);
@@ -529,32 +505,15 @@ mod tests {
         );
 
         let a = TestPoly {
-            coeffs: vec![
-                R::try_from(0).unwrap(),
-                R::try_from(1).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(0).unwrap(),
-            ],
+            coeffs: vec![R::from(0), R::from(1), R::from(2), R::from(0)],
         };
 
         let b = TestPoly {
-            coeffs: vec![
-                R::try_from(0).unwrap(),
-                R::try_from(1).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(0).unwrap(),
-                R::try_from(0).unwrap(),
-            ],
+            coeffs: vec![R::from(0), R::from(1), R::from(2), R::from(0), R::from(0)],
         };
 
         let c = TestPoly {
-            coeffs: vec![
-                R::try_from(0).unwrap(),
-                R::try_from(1).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(3).unwrap(),
-                R::try_from(0).unwrap(),
-            ],
+            coeffs: vec![R::from(0), R::from(1), R::from(2), R::from(3), R::from(0)],
         };
 
         assert_eq!(a, a);
@@ -573,21 +532,17 @@ mod tests {
 
         let a = TestPoly {
             coeffs: vec![
-                R::try_from(1).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(0).unwrap(),
-                R::try_from(4).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(3).unwrap(),
+                R::from(1),
+                R::from(2),
+                R::from(0),
+                R::from(4),
+                R::from(2),
+                R::from(3),
             ],
         };
 
         let b = TestPoly {
-            coeffs: vec![
-                R::try_from(1).unwrap(),
-                R::try_from(1).unwrap(),
-                R::try_from(1).unwrap(),
-            ],
+            coeffs: vec![R::from(1), R::from(1), R::from(1)],
         };
 
         let (q, rem) = a.vartime_div_rem_restricted_rhs(&b);
@@ -608,23 +563,18 @@ mod tests {
 
         let a = TestPoly {
             coeffs: vec![
-                R::try_from(1).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(0).unwrap(),
-                R::try_from(4).unwrap(),
-                R::try_from(2).unwrap(),
-                R::try_from(3).unwrap(),
-                R::try_from(0).unwrap(),
+                R::from(1),
+                R::from(2),
+                R::from(0),
+                R::from(4),
+                R::from(2),
+                R::from(3),
+                R::from(0),
             ],
         };
 
         let b = TestPoly {
-            coeffs: vec![
-                R::try_from(1).unwrap(),
-                R::try_from(1).unwrap(),
-                R::try_from(1).unwrap(),
-                R::try_from(0).unwrap(),
-            ],
+            coeffs: vec![R::from(1), R::from(1), R::from(1), R::from(0)],
         };
 
         let (q, rem) = a.vartime_div_rem_restricted_rhs(&b);
@@ -653,7 +603,7 @@ mod tests {
 
             for _ in 0..target_den_degree {
                 let coeff = Uniform::from(0..1234u64).sample(&mut thread_rng());
-                den.coeffs.push(R::try_from(coeff).unwrap());
+                den.coeffs.push(R::from(coeff));
             }
 
             // Leading coefficient in denominator must be a 1.
@@ -661,7 +611,7 @@ mod tests {
 
             for _ in 0..=target_num_degree {
                 let coeff = Uniform::from(0..1234u64).sample(&mut thread_rng());
-                num.coeffs.push(R::try_from(coeff).unwrap());
+                num.coeffs.push(R::from(coeff));
             }
 
             let (q, rem) = num.vartime_div_rem_restricted_rhs(&den);

--- a/sunscreen_runtime/src/runtime.rs
+++ b/sunscreen_runtime/src/runtime.rs
@@ -604,7 +604,7 @@ where
                         Ok(ciphertext)
                     })
                     .collect::<Result<Vec<SealCiphertext>>>()?
-                    .drain(0..)
+                    .into_iter()
                     .map(|c| WithContext {
                         params: fhe_data.params.clone(),
                         data: c,


### PR DESCRIPTION
This PR contains the SDLP prover/verifier knowledge generation from a set of BFV encryption statements. Everything here has been added to `logproof` and written in terms of `seal_fhe`, so it is a bit of a lower level API than what will be used by a sunscreen library consumer.

Next up will be a higher level API added to `sunscreen_runtime`, making use of the new `logproof::bfv_statement` under the hood. Once I've adapted everything in that crate to use the new swag, I can also remove the existing `logproof::test`, `LatticeProblem`, etc.