### PR TITLE
Fix linked proof commitments

### DIFF
--- a/sunscreen/tests/linked.rs
+++ b/sunscreen/tests/linked.rs
@@ -265,7 +265,6 @@ mod linked_tests {
     }
 
     #[test]
-    #[ignore = "bug in linked input multplication"]
     fn can_compare_rationals() {
         let app = Compiler::new()
             .fhe_program(doggie)

--- a/sunscreen_compiler_common/src/graph.rs
+++ b/sunscreen_compiler_common/src/graph.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
 use petgraph::{
     dot::Dot,
@@ -215,14 +215,14 @@ where
         Direction::Incoming
     };
 
-    let mut ready_nodes: Vec<NodeIndex> = graph
+    let mut ready_nodes: VecDeque<NodeIndex> = graph
         .node_identifiers()
         .filter(|&x| graph.neighbors_directed(x, prev_direction).next().is_none())
         .collect();
 
     ready.extend(ready_nodes.iter());
 
-    while let Some(n) = ready_nodes.pop() {
+    while let Some(n) = ready_nodes.pop_front() {
         visited.insert(n);
 
         // Remember the next nodes from the current node in case it gets deleted.
@@ -244,7 +244,7 @@ where
             for i in graph.neighbors_directed(n, next_direction) {
                 if !ready.contains(&i) && node_ready(i) {
                     ready.insert(i);
-                    ready_nodes.push(i);
+                    ready_nodes.push_back(i);
                 }
             }
         }
@@ -253,7 +253,7 @@ where
         for i in next_nodes {
             if !ready.contains(&i) && node_ready(i) {
                 ready.insert(i);
-                ready_nodes.push(i);
+                ready_nodes.push_back(i);
             }
         }
 
@@ -261,7 +261,7 @@ where
         for i in added_nodes {
             if graph.neighbors_directed(i, prev_direction).next().is_none() {
                 ready.insert(i);
-                ready_nodes.push(i);
+                ready_nodes.push_back(i);
             }
         }
     }


### PR DESCRIPTION
The current graph traversal logic is depth first. Thus on the ZKP side, the multiplier gates corresponding to the inputs will not be contiguous as they are allocated into the prover's `Secret::{a_L,a_R}`. In fact, determining the location of the input gates is not generally feasible (any multiplications performed with said inputs are going to be evaluated during the graph traversal as soon as those inputs are .. inputted).

This PR changes the graph traversal to be breadth first, so we allocate all the inputs first, in one contiguous block, and _then_ we handle any downstream multiplications in the circuit.

Furthermore, since we're using a `VecDeque` to deque ready nodes, we may as well pop them from the front. This allows for a more intuitive traversal of the inputs in order, so we don't need to handle any reversal or odd pending final multiplier case when constructing the shared generators.

The tests pass, so it seems we didn't have any correctness assumptions on this traversal. But this change is a low level detail of the compiler to both FHE and ZKP, so we ought to think carefully about any ramifications. There could be performance impacts to FHE/ZKP program compilation. If desired we could diverge the FHE/ZKP compilation so that only ZKP uses the breadth first approach, but only if there is a good reason to do so.