### PR TITLE
Expose symmetric encryptions

### DIFF
--- a/benchmarks/cannonical_norm_noise_model/src/ops.rs
+++ b/benchmarks/cannonical_norm_noise_model/src/ops.rs
@@ -66,7 +66,7 @@ fn make_seal_things(
     SecretKey,
     Option<RelinearizationKeys>,
     Option<GaloisKeys>,
-    Encryptor,
+    AsymmetricEncryptor,
     Decryptor,
     BFVEvaluator,
 ) {

--- a/logproof/src/bfv_statement.rs
+++ b/logproof/src/bfv_statement.rs
@@ -650,7 +650,7 @@ mod tests {
     use rand::Rng;
     use seal_fhe::{
         BfvEncryptionParametersBuilder, CoefficientModulus, Context, Encryptor, KeyGenerator,
-        PlainModulus, SecurityLevel,
+        PlainModulus, SecurityLevel, SymAsym,
     };
 
     use crate::{
@@ -761,7 +761,7 @@ mod tests {
         params: EncryptionParameters,
         public_key: PublicKey,
         secret_key: SecretKey,
-        encryptor: Encryptor,
+        encryptor: Encryptor<SymAsym>,
     }
 
     impl BFVTestContext {

--- a/logproof/src/test.rs
+++ b/logproof/src/test.rs
@@ -71,7 +71,7 @@ where
     // Generate plaintext data
     let plaintext = encoder.encode_unsigned(message).unwrap();
 
-    let (ciphertext, u, e, r) = encryptor.encrypt_return_components(&plaintext).unwrap();
+    let (ciphertext, components) = encryptor.encrypt_return_components(&plaintext).unwrap();
 
     let decrypted = decryptor.decrypt(&ciphertext).unwrap();
     let data = encoder.decode_unsigned(&decrypted).unwrap();
@@ -86,6 +86,6 @@ where
         ciphertext,
         public_key: Cow::Borrowed(&public_key),
     };
-    let witness = BfvWitness::PublicKeyEncryption { u, e, r };
+    let witness = BfvWitness::PublicKeyEncryption(components);
     generate_prover_knowledge(&[statement], &[message], &[witness], &params, &ctx)
 }

--- a/seal_fhe/src/bfv_evaluator.rs
+++ b/seal_fhe/src/bfv_evaluator.rs
@@ -254,7 +254,7 @@ mod tests {
 
     fn run_bfv_test<F>(test: F)
     where
-        F: FnOnce(Decryptor, BFVEncoder, Encryptor, BFVEvaluator, KeyGenerator),
+        F: FnOnce(Decryptor, BFVEncoder, Encryptor<SymAsym>, BFVEvaluator, KeyGenerator),
     {
         let params = BfvEncryptionParametersBuilder::new()
             .set_poly_modulus_degree(8192)

--- a/seal_fhe/src/data_structures.rs
+++ b/seal_fhe/src/data_structures.rs
@@ -314,8 +314,8 @@ impl Drop for PolynomialArray {
 #[cfg(test)]
 mod tests {
     use crate::{
-        BFVEncoder, BfvEncryptionParametersBuilder, CoefficientModulus, Encryptor, KeyGenerator,
-        Modulus, PlainModulus, Plaintext, SecurityLevel,
+        AsymmetricComponents, BFVEncoder, BfvEncryptionParametersBuilder, CoefficientModulus,
+        Encryptor, KeyGenerator, Modulus, PlainModulus, Plaintext, SecurityLevel,
     };
 
     use super::*;
@@ -388,7 +388,8 @@ mod tests {
         let encryptor =
             Encryptor::with_public_and_secret_key(&ctx, &public_key, &secret_key).unwrap();
 
-        let (ciphertext, u, e, r) = encryptor.encrypt_return_components(&plaintext).unwrap();
+        let (ciphertext, AsymmetricComponents { u, e, r }) =
+            encryptor.encrypt_return_components(&plaintext).unwrap();
 
         (ctx, coeff_modulus, public_key, ciphertext, u, e, r)
     }

--- a/seal_fhe/src/data_structures.rs
+++ b/seal_fhe/src/data_structures.rs
@@ -6,6 +6,7 @@ use crate::error::*;
 use crate::Ciphertext;
 use crate::Context;
 use crate::PublicKey;
+use crate::SecretKey;
 
 /**
  * A SEAL array storing a number of polynomials. In particular, type implements
@@ -89,6 +90,25 @@ impl PolynomialArray {
                 null_mut(),
                 context.get_handle(),
                 public_key.get_handle(),
+                &mut handle,
+            )
+        })?;
+
+        Ok(Self { handle })
+    }
+
+    /**
+     * Creates a polynomial array from a reference to a secret key.
+     */
+    pub fn new_from_secret_key(context: &Context, secret_key: &SecretKey) -> Result<Self> {
+        let mut handle: *mut c_void = null_mut();
+
+        // By giving an empty pool handle we acquire the global one (first argument to create).
+        convert_seal_error(unsafe {
+            bindgen::PolynomialArray_CreateFromSecretKey(
+                null_mut(),
+                context.get_handle(),
+                secret_key.get_handle(),
                 &mut handle,
             )
         })?;

--- a/seal_fhe/src/encryptor_decryptor.rs
+++ b/seal_fhe/src/encryptor_decryptor.rs
@@ -175,7 +175,6 @@ impl Encryptor {
     }
 
     /**
-     *
      * DO NOT USE THIS FUNCTION IN PRODUCTION: IT PRODUCES DETERMINISTIC
      * ENCRYPTIONS. IT IS INHERENTLY INSECURE, AND ONLY MEANT FOR TESTING OR
      * DEMONSTRATION PURPOSES.
@@ -293,6 +292,49 @@ impl Encryptor {
                 plaintext.get_handle(),
                 false,
                 ciphertext.get_handle(),
+                null_mut(),
+            )
+        })?;
+
+        Ok(ciphertext)
+    }
+
+    /**
+     * DO NOT USE THIS FUNCTION IN PRODUCTION: IT PRODUCES DETERMINISTIC
+     * ENCRYPTIONS. IT IS INHERENTLY INSECURE, AND ONLY MEANT FOR TESTING OR
+     * DEMONSTRATION PURPOSES.
+     *
+     * Encrypts a plaintext with the secret key and returns the ciphertext as a
+     * serializable object.
+     *
+     * The encryption parameters for the resulting ciphertext correspond to:
+     * 1) in BFV, the highest (data) level in the modulus switching chain,
+     * 2) in CKKS, the encryption parameters of the plaintext.
+     * Dynamic memory allocations in the process are allocated from the memory
+     * pool pointed to by the given MemoryPoolHandle.
+     *
+     * * `plainext` - The plaintext to encrypt.
+     * * `seed` - The seed to use for encryption.
+     */
+    #[cfg(feature = "deterministic")]
+    pub fn encrypt_symmetric_deterministic(
+        &self,
+        plaintext: &Plaintext,
+        seed: &[u64; 8],
+    ) -> Result<Ciphertext> {
+        let ciphertext = Ciphertext::new()?;
+        let e_destination = PolynomialArray::new()?;
+        let r_destination = Plaintext::new()?;
+
+        // We do not need the components so we do not export them.
+        convert_seal_error(unsafe {
+            bindgen::Encryptor_EncryptSymmetricReturnComponentsSetSeed(
+                self.handle,
+                plaintext.get_handle(),
+                ciphertext.get_handle(),
+                e_destination.get_handle(),
+                r_destination.get_handle(),
+                seed.as_ptr() as *mut c_void,
                 null_mut(),
             )
         })?;

--- a/seal_fhe/src/encryptor_decryptor.rs
+++ b/seal_fhe/src/encryptor_decryptor.rs
@@ -736,7 +736,7 @@ mod tests {
         use std::collections::hash_map::DefaultHasher;
         use std::hash::{Hash, Hasher};
 
-        use crate::*;
+        use super::*;
 
         #[test]
         fn encrypt_deterministic() {

--- a/seal_fhe/src/encryptor_decryptor.rs
+++ b/seal_fhe/src/encryptor_decryptor.rs
@@ -629,7 +629,4 @@ mod tests {
             );
         }
     }
-
-    #[cfg(feature = "deterministic")]
-    pub use deterministic::*;
 }

--- a/seal_fhe/src/encryptor_decryptor.rs
+++ b/seal_fhe/src/encryptor_decryptor.rs
@@ -90,6 +90,9 @@ pub type SymmetricEncryptor = Encryptor<Sym>;
 /// An encryptor capable of asymmetric encryptions.
 pub type AsymmetricEncryptor = Encryptor<Asym>;
 
+/// An encryptor capable of both symmetric and asymmetric encryptions.
+pub type SymAsymEncryptor = Encryptor<SymAsym>;
+
 mod sealed {
     pub trait Sealed {}
     impl Sealed for super::Sym {}
@@ -209,6 +212,13 @@ impl SymmetricEncryptor {
     /// Create a new symmetric encryptor.
     pub fn new(ctx: &Context, secret_key: &SecretKey) -> Result<Self> {
         Encryptor::with_secret_key(ctx, secret_key)
+    }
+}
+
+impl SymAsymEncryptor {
+    /// Create a new encryptor capable of both symmetric and asymmetric encryption.
+    pub fn new(ctx: &Context, public_key: &PublicKey, secret_key: &SecretKey) -> Result<Self> {
+        Encryptor::with_public_and_secret_key(ctx, public_key, secret_key)
     }
 }
 

--- a/seal_fhe/src/lib.rs
+++ b/seal_fhe/src/lib.rs
@@ -61,7 +61,10 @@ pub use context::Context;
 pub use data_structures::PolynomialArray;
 pub use encoder::{BFVEncoder, BFVScalarEncoder};
 pub use encryption_parameters::*;
-pub use encryptor_decryptor::{AsymmetricComponents, Decryptor, Encryptor, SymmetricComponents};
+pub use encryptor_decryptor::{
+    marker as enc_marker, Asym, AsymmetricComponents, AsymmetricEncryptor, Decryptor, Encryptor,
+    Sym, SymAsym, SymmetricComponents, SymmetricEncryptor,
+};
 pub use error::{Error, Result};
 pub use evaluator::Evaluator;
 pub use key_generator::{GaloisKeys, KeyGenerator, PublicKey, RelinearizationKeys, SecretKey};

--- a/seal_fhe/src/lib.rs
+++ b/seal_fhe/src/lib.rs
@@ -61,7 +61,7 @@ pub use context::Context;
 pub use data_structures::PolynomialArray;
 pub use encoder::{BFVEncoder, BFVScalarEncoder};
 pub use encryption_parameters::*;
-pub use encryptor_decryptor::{Decryptor, Encryptor};
+pub use encryptor_decryptor::{AsymmetricComponents, Decryptor, Encryptor, SymmetricComponents};
 pub use error::{Error, Result};
 pub use evaluator::Evaluator;
 pub use key_generator::{GaloisKeys, KeyGenerator, PublicKey, RelinearizationKeys, SecretKey};

--- a/seal_fhe/tests/test_common.rs
+++ b/seal_fhe/tests/test_common.rs
@@ -2,7 +2,7 @@ use seal_fhe::*;
 
 pub fn run_bfv_test<F>(lane_bits: u32, degree: u64, test: F)
 where
-    F: FnOnce(Decryptor, BFVEncoder, Encryptor, BFVEvaluator, KeyGenerator),
+    F: FnOnce(Decryptor, BFVEncoder, Encryptor<SymAsym>, BFVEvaluator, KeyGenerator),
 {
     let params = BfvEncryptionParametersBuilder::new()
         .set_poly_modulus_degree(degree)

--- a/sunscreen/tests/linked.rs
+++ b/sunscreen/tests/linked.rs
@@ -229,7 +229,7 @@ mod linked_tests {
         let rt = FheZkpRuntime::new(app.params(), &BulletproofsBackend::new()).unwrap();
         let compare_signed_zkp = app.get_zkp_program(compare_signed).unwrap();
 
-        let (public_key, _secret_key) = rt.generate_keys().unwrap();
+        let (public_key, private_key) = rt.generate_keys().unwrap();
 
         // To slow to run in a loop :/ if we eventually expose small params for testing, do more
         // cases
@@ -240,7 +240,9 @@ mod linked_tests {
 
             let mut proof_builder = LogProofBuilder::new(&rt);
             let (_ct, x_msg) = proof_builder.encrypt_and_link(&x, &public_key).unwrap();
-            let (_ct, y_msg) = proof_builder.encrypt_and_link(&y, &public_key).unwrap();
+            let (_ct, y_msg) = proof_builder
+                .encrypt_symmetric_and_link(&y, &private_key)
+                .unwrap();
             proof_builder
                 .zkp_program(compare_signed_zkp)
                 .unwrap()
@@ -332,7 +334,7 @@ mod linked_tests {
         let rt = FheZkpRuntime::new(app.params(), &BulletproofsBackend::new()).unwrap();
         let is_eq_zkp = app.get_zkp_program(is_eq_3).unwrap();
 
-        let (public_key, _secret_key) = rt.generate_keys().unwrap();
+        let (public_key, private_key) = rt.generate_keys().unwrap();
 
         for val in [3, 0, -3] {
             let mut proof_builder = LogProofBuilder::new(&rt);
@@ -343,7 +345,7 @@ mod linked_tests {
             let _ct_x1 = proof_builder.encrypt_linked(&x_msg, &public_key).unwrap();
             // proves same value within ZKP
             let (_ct_y, y_msg) = proof_builder
-                .encrypt_and_link(&Signed::from(val), &public_key)
+                .encrypt_symmetric_and_link(&Signed::from(val), &private_key)
                 .unwrap();
             proof_builder
                 .zkp_program(is_eq_zkp)

--- a/sunscreen/tests/sdlp.rs
+++ b/sunscreen/tests/sdlp.rs
@@ -31,18 +31,32 @@ mod sdlp_tests {
     }
 
     #[test]
-    fn prove_linked_asymmetric_statements() {
+    fn prove_one_symmetric_statement() {
         let rt = FheRuntime::new(&SMALL_PARAMS).unwrap();
-        let (public_key, _secret_key) = rt.generate_keys().unwrap();
+        let (_public_key, private_key) = rt.generate_keys().unwrap();
+        let mut logproof_builder = LogProofBuilder::new(&rt);
+
+        let _ct = logproof_builder
+            .encrypt_symmetric(&Signed::from(3), &private_key)
+            .unwrap();
+
+        let sdlp = logproof_builder.build_logproof().unwrap();
+        sdlp.verify().unwrap();
+    }
+
+    #[test]
+    fn prove_linked_statements() {
+        let rt = FheRuntime::new(&SMALL_PARAMS).unwrap();
+        let (public_key, private_key) = rt.generate_keys().unwrap();
         let mut logproof_builder = LogProofBuilder::new(&rt);
 
         let (_a1, linked_a) = logproof_builder
             .encrypt_and_link(&Signed::from(2), &public_key)
             .unwrap();
         let _a2 = logproof_builder
-            .encrypt_linked(&linked_a, &public_key)
+            .encrypt_symmetric_linked(&linked_a, &private_key)
             .unwrap();
-        let _b = logproof_builder
+        let _other = logproof_builder
             .encrypt(&Signed::from(3), &public_key)
             .unwrap();
         let sdlp = logproof_builder.build_logproof().unwrap();

--- a/sunscreen_runtime/src/builder.rs
+++ b/sunscreen_runtime/src/builder.rs
@@ -523,7 +523,6 @@ mod linked {
                     self.witness
                         .push(BfvWitness::PublicKeyEncryption(components));
                     i += 1;
-                    Ok(())
                 })
         }
 
@@ -559,7 +558,6 @@ mod linked {
                         components,
                     });
                     i += 1;
-                    Ok(())
                 },
             )
         }

--- a/sunscreen_runtime/src/builder.rs
+++ b/sunscreen_runtime/src/builder.rs
@@ -372,7 +372,7 @@ mod linked {
             P: TryIntoPlaintext + TypeName,
         {
             let pt = self.plaintext_typed(message)?;
-            self.encrypt_internal(Message::Plain(pt), public_key, None)
+            self.encrypt_asymmetric_internal(Message::Plain(pt), public_key, None)
         }
 
         /// Encrypt a plaintext symmetrically, adding the encryption statement to the proof.
@@ -435,7 +435,7 @@ mod linked {
             let plaintext_typed = self.plaintext_typed(message)?;
             let idx_start = self.messages.len();
             let ct = match key {
-                Key::Public(public_key) => self.encrypt_internal(
+                Key::Public(public_key) => self.encrypt_asymmetric_internal(
                     Message::Plain(plaintext_typed.clone()),
                     public_key,
                     Some(self.mk_bounds::<P>()),
@@ -474,7 +474,7 @@ mod linked {
         ) -> Result<Ciphertext> {
             // The existing message already has bounds, no need to recompute them.
             let bounds = None;
-            self.encrypt_internal(Message::Linked(message.clone()), public_key, bounds)
+            self.encrypt_asymmetric_internal(Message::Linked(message.clone()), public_key, bounds)
         }
 
         /// Encrypt a linked message symmetrically, adding the new encryption statement to the
@@ -494,7 +494,7 @@ mod linked {
             self.encrypt_symmetric_internal(Message::Linked(message.clone()), private_key, bounds)
         }
 
-        fn encrypt_internal(
+        fn encrypt_asymmetric_internal(
             &mut self,
             message: Message,
             public_key: &'k PublicKey,

--- a/sunscreen_runtime/src/builder.rs
+++ b/sunscreen_runtime/src/builder.rs
@@ -503,7 +503,7 @@ mod linked {
             let existing_idx = message.linked_id();
             let mut i = 0;
             self.runtime
-                .encrypt_map_components(&message, public_key, |m, ct, u, e, r| {
+                .encrypt_map_components(&message, public_key, |m, ct, components| {
                     let message_id = if let Some(idx) = existing_idx {
                         idx + i
                     } else {
@@ -521,7 +521,7 @@ mod linked {
                             public_key: Cow::Borrowed(&public_key.public_key.data),
                         });
                     self.witness
-                        .push(BfvWitness::PublicKeyEncryption { u, e, r: r.clone() });
+                        .push(BfvWitness::PublicKeyEncryption(components));
                     i += 1;
                     Ok(())
                 })
@@ -535,8 +535,10 @@ mod linked {
         ) -> Result<Ciphertext> {
             let existing_idx = message.linked_id();
             let mut i = 0;
-            self.runtime
-                .encrypt_symmetric_map_components(&message, private_key, |m, ct, e, r| {
+            self.runtime.encrypt_symmetric_map_components(
+                &message,
+                private_key,
+                |m, ct, components| {
                     let message_id = if let Some(idx) = existing_idx {
                         idx + i
                     } else {
@@ -554,12 +556,12 @@ mod linked {
                         });
                     self.witness.push(BfvWitness::PrivateKeyEncryption {
                         private_key: Cow::Borrowed(&private_key.0.data),
-                        e,
-                        r,
+                        components,
                     });
                     i += 1;
                     Ok(())
-                })
+                },
+            )
         }
 
         fn plaintext_typed<P>(&self, pt: &P) -> Result<PlaintextTyped>

--- a/sunscreen_runtime/src/builder.rs
+++ b/sunscreen_runtime/src/builder.rs
@@ -308,6 +308,20 @@ mod linked {
         }
     }
 
+    // Infallible since we've already obtained the plaintext
+    impl TryIntoPlaintext for Message {
+        fn try_into_plaintext(&self, _params: &Params) -> Result<Plaintext> {
+            Ok(self.pt().clone())
+        }
+    }
+
+    // Forward to the underlying plaintext type
+    impl crate::TypeNameInstance for Message {
+        fn type_name_instance(&self) -> Type {
+            self.type_name().clone()
+        }
+    }
+
     /// A builder for [`Sdlp`] or [`LinkedProof`].
     ///
     /// Use this builder to encrypt your [`Plaintext`]s while automatically generate a log proof of the
@@ -415,13 +429,9 @@ mod linked {
             public_key: &'k PublicKey,
             bounds: Option<Bounds>,
         ) -> Result<Ciphertext> {
-            let enc_components = self.runtime.encrypt_return_components_switched_internal(
-                message.pt(),
-                message.type_name(),
-                public_key,
-                true,
-                None,
-            )?;
+            let enc_components = self
+                .runtime
+                .encrypt_return_components(&message, public_key)?;
             let existing_idx = message.linked_id();
 
             for (i, AsymmetricEncryption { ct, u, e, r, m }) in

--- a/sunscreen_runtime/src/run.rs
+++ b/sunscreen_runtime/src/run.rs
@@ -556,7 +556,7 @@ mod tests {
         Context,
         PublicKey,
         SecretKey,
-        Encryptor,
+        Encryptor<SymAsym>,
         Decryptor,
         BFVEvaluator,
     ) {

--- a/sunscreen_runtime/src/runtime.rs
+++ b/sunscreen_runtime/src/runtime.rs
@@ -85,6 +85,7 @@ pub(crate) struct BFVEncryptionComponents {
 }
 
 // TODO remove the plaintext wrapper type from r, its useless and not necessary given that polynomial array types also come from seal layer.
+// Or, since we're exposing secretkey -> polyarray and that requires plaintext -> polyarray, just have r be exported as a polyarray as well.
 
 /// Components needed to perform BFV symmetric encryption. Specifically, BFV is defined by the
 /// following equation in SEAL:
@@ -791,6 +792,7 @@ trait SealEncrypt {
         F: Fn(&Self, &SealPlaintext) -> Result<Self::IntermediaryComponents>;
 }
 
+// This impl should have all asymmetric encryption methods.
 impl SealEncrypt for Asymmetric {
     type Key = PublicKey;
     type IntermediaryComponents = (
@@ -880,6 +882,7 @@ impl SealEncrypt for Asymmetric {
     }
 }
 
+// This impl should have all symmetric encryption methods.
 impl SealEncrypt for Symmetric {
     type Key = PrivateKey;
     type IntermediaryComponents = (SealCiphertext, PolynomialArray, SealPlaintext);

--- a/sunscreen_runtime/src/runtime.rs
+++ b/sunscreen_runtime/src/runtime.rs
@@ -28,42 +28,6 @@ use sunscreen_zkp_backend::BigInt;
 use sunscreen_zkp_backend::Proof;
 use sunscreen_zkp_backend::ZkpBackend;
 
-#[cfg(feature = "deterministic")]
-fn encrypt_function(
-    encryptor: &Encryptor,
-    val: &seal_fhe::Plaintext,
-    seed: Option<&[u64; 8]>,
-) -> Result<(
-    seal_fhe::Ciphertext,
-    PolynomialArray,
-    PolynomialArray,
-    seal_fhe::Plaintext,
-)> {
-    let result = if let Some(seed) = seed {
-        encryptor.encrypt_return_components_deterministic(val, seed)
-    } else {
-        encryptor.encrypt_return_components(val)
-    };
-
-    result.map_err(Error::SealError)
-}
-
-#[cfg(not(feature = "deterministic"))]
-fn encrypt_function(
-    encryptor: &Encryptor,
-    val: &seal_fhe::Plaintext,
-    _seed: Option<&[u64; 8]>,
-) -> Result<(
-    seal_fhe::Ciphertext,
-    PolynomialArray,
-    PolynomialArray,
-    seal_fhe::Plaintext,
-)> {
-    encryptor
-        .encrypt_return_components(val)
-        .map_err(Error::SealError)
-}
-
 enum Context {
     Seal(SealContext),
 }
@@ -85,38 +49,64 @@ pub mod marker {
     pub trait Zkp {}
 }
 
-/**
- * Components needed to perform BFV encryption. Specifically, BFV is defined by the following equation in SEAL:
- *
- * 1. $\Delta m + r + p_0 u + e_1 = c_0$
- * 2. $p_1 u + e_2 = c_1$
- *
- * where
- * - $\Delta$ is the floored ratio of the coefficient and plaintext modulus
- *   (floor(q/t)).
- * - $m$ is the message encoded as a SEAL plaintext.
- * - $r$ is the remainder from the delta calculation that SEAL adds to the
- *   ciphertext to handle rounding.
- * - $p_i$ is the $i$th component of the public key, starting at index 0.
- * - $u$ is a randomly sampled ternary polynomial (coefficients are sampled from
- *   {-1, 0, 1} mod q).
- * - $e_i$ is the $i$th component of the noise added to the ciphertext, starting
- *   at index 1. These values are sampled from a centered binomial distribution
- *   with a standard deviation of 3.2.
- * - $c_i$ is the $i$th component of the ciphertext, starting at index 0.
- *
- * Note that the indices used here match the SEAL/manual and the original paper,
- * where $p_i$ is used with the error term $e_{i + 1}$ and where $e_0$ does not
- * exist.
- *
- * Since the ciphertext can contain more that one ciphertext underneath, each of
- * the components is returned as a vector of the components matching the number
- * of ciphertexts.
- */
+/// Components needed to perform BFV asymmetric encryption. Specifically, BFV is defined by the
+/// following equation in SEAL:
+///
+/// 1. $\Delta m + r + p_0 u + e_1 = c_0$
+/// 2. $p_1 u + e_2 = c_1$
+///
+/// where
+/// - $\Delta$ is the floored ratio of the coefficient and plaintext modulus
+///   (floor(q/t)).
+/// - $m$ is the message encoded as a SEAL plaintext.
+/// - $r$ is the remainder from the delta calculation that SEAL adds to the
+///   ciphertext to handle rounding.
+/// - $p_i$ is the $i$th component of the public key, starting at index 0.
+/// - $u$ is a randomly sampled ternary polynomial (coefficients are sampled from
+///   {-1, 0, 1} mod q).
+/// - $e_i$ is the $i$th component of the noise added to the ciphertext, starting
+///   at index 1. These values are sampled from a centered binomial distribution
+///   with a standard deviation of 3.2.
+/// - $c_i$ is the $i$th component of the ciphertext, starting at index 0.
+///
+/// Note that the indices used here match the SEAL/manual and the original paper,
+/// where $p_i$ is used with the error term $e_{i + 1}$ and where $e_0$ does not
+/// exist.
+///
+/// Since the ciphertext can contain more that one ciphertext underneath, each of
+/// the components is returned as a vector of the components matching the number
+/// of ciphertexts.
 #[allow(unused)]
-pub struct BFVEncryptionComponents {
+pub(crate) struct BFVEncryptionComponents {
     pub(crate) ciphertext: Ciphertext,
     pub(crate) u: Vec<PolynomialArray>,
+    pub(crate) e: Vec<PolynomialArray>,
+    pub(crate) r: Vec<Plaintext>,
+}
+
+/// Components needed to perform BFV symmetric encryption. Specifically, BFV is defined by the
+/// following equation in SEAL:
+///
+/// 1. $\Delta m + r - (a s + e) = c_0$
+/// 2. $a = c_1$
+///
+/// where
+/// - $\Delta$ is the floored ratio of the coefficient and plaintext modulus
+///   (floor(q/t)).
+/// - $m$ is the message encoded as a SEAL plaintext.
+/// - $r$ is the remainder from the delta calculation that SEAL adds to the
+///   ciphertext to handle rounding.
+/// - $a$ is a randomly sampled polynomial (coefficients are sampled uniformly in $\mathbb{Z}_q$).
+/// - $e$ is the noise added to the ciphertext, sampled from a centered binomial distribution
+///   with a standard deviation of 3.2.
+/// - $c_i$ is the $i$th component of the ciphertext, starting at index 0.
+///
+/// Since the ciphertext can contain more that one ciphertext underneath, each of
+/// the components is returned as a vector of the components matching the number
+/// of ciphertexts.
+#[allow(unused)]
+pub(crate) struct BFVSymmetricEncryptionComponents {
+    pub(crate) ciphertext: Ciphertext,
     pub(crate) e: Vec<PolynomialArray>,
     pub(crate) r: Vec<Plaintext>,
 }
@@ -484,8 +474,71 @@ where
     where
         P: TryIntoPlaintext + TypeName,
     {
-        self.encrypt_return_components_switched(val, public_key, false, None)
-            .map(|x| x.ciphertext)
+        let fhe_data = self.runtime_data.unwrap_fhe();
+        match (
+            &fhe_data.context,
+            &val.try_into_plaintext(&fhe_data.params)?.inner,
+        ) {
+            (Context::Seal(context), InnerPlaintext::Seal(inner_plain)) => {
+                let encryptor = Encryptor::with_public_key(&context, &public_key.public_key.data)?;
+                let ciphertexts = inner_plain
+                    .iter()
+                    .map(|p| {
+                        let ct = WithContext {
+                            params: fhe_data.params.clone(),
+                            data: encryptor.encrypt(p).map_err(Error::SealError)?,
+                        };
+                        Ok(ct)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                Ok(Ciphertext {
+                    data_type: Type {
+                        is_encrypted: true,
+                        ..P::type_name().clone()
+                    },
+                    inner: InnerCiphertext::Seal(ciphertexts),
+                })
+            }
+        }
+    }
+
+    /// Encrypts the given [`FheType`](crate::FheType) symmetrically using the given secret
+    /// key.
+    ///
+    /// Returns [`Error::ParameterMismatch`] if the plaintext is incompatible with this runtime's
+    /// scheme.
+    pub fn encrypt_symmetric<P>(&self, val: P, private_key: &PrivateKey) -> Result<Ciphertext>
+    where
+        P: TryIntoPlaintext + TypeName,
+    {
+        let fhe_data = self.runtime_data.unwrap_fhe();
+        match (
+            &fhe_data.context,
+            &val.try_into_plaintext(&fhe_data.params)?.inner,
+        ) {
+            (Context::Seal(context), InnerPlaintext::Seal(inner_plain)) => {
+                let encryptor = Encryptor::with_secret_key(context, &private_key.0.data)?;
+                let ciphertexts = inner_plain
+                    .iter()
+                    .map(|p| {
+                        let ct = WithContext {
+                            params: fhe_data.params.clone(),
+                            data: encryptor.encrypt_symmetric(p).map_err(Error::SealError)?,
+                        };
+                        Ok(ct)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                Ok(Ciphertext {
+                    data_type: Type {
+                        is_encrypted: true,
+                        ..P::type_name().clone()
+                    },
+                    inner: InnerCiphertext::Seal(ciphertexts),
+                })
+            }
+        }
     }
 
     /**
@@ -508,8 +561,35 @@ where
     where
         P: TryIntoPlaintext + TypeName,
     {
-        self.encrypt_return_components_switched(val, public_key, false, Some(seed))
-            .map(|x| x.ciphertext)
+        let fhe_data = self.runtime_data.unwrap_fhe();
+        match (
+            &fhe_data.context,
+            &val.try_into_plaintext(&fhe_data.params)?.inner,
+        ) {
+            (Context::Seal(context), InnerPlaintext::Seal(inner_plain)) => {
+                let encryptor = Encryptor::with_public_key(&context, &public_key.public_key.data)?;
+                let ciphertexts = inner_plain
+                    .iter()
+                    .map(|p| {
+                        let ct = WithContext {
+                            params: fhe_data.params.clone(),
+                            data: encryptor
+                                .encrypt_deterministic(p)
+                                .map_err(Error::SealError)?,
+                        };
+                        Ok(ct)
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                Ok(Ciphertext {
+                    data_type: Type {
+                        is_encrypted: true,
+                        ..P::type_name().clone()
+                    },
+                    inner: InnerCiphertext::Seal(ciphertexts),
+                })
+            }
+        }
     }
 
     #[allow(dead_code)]
@@ -528,7 +608,9 @@ where
     where
         P: TryIntoPlaintext + TypeName,
     {
-        self.encrypt_return_components_switched(val, public_key, true, None)
+        let plaintext = val.try_into_plaintext(self.params())?;
+        let plaintext_type = P::type_name();
+        self.encrypt_return_components_internal(&plaintext, &plaintext_type, public_key, None)
     }
 
     /**
@@ -543,7 +625,7 @@ where
      */
     #[cfg(feature = "deterministic")]
     #[allow(dead_code)]
-    fn encrypt_return_components_deterministic<P>(
+    pub(crate) fn encrypt_return_components_deterministic<P>(
         &self,
         val: P,
         public_key: &PublicKey,
@@ -552,58 +634,35 @@ where
     where
         P: TryIntoPlaintext + TypeName,
     {
-        self.encrypt_return_components_switched(val, public_key, true, Some(seed))
-    }
-
-    /**
-     * Encrypts the given [`FheType`](crate::FheType) using the given public
-     * key, returning the encrypted value along with the components added to the
-     * message. See `BFVEncryptionComponents` for the pieces returned.
-     *
-     * Note that this will disable the special modulus!
-     *
-     * Returns [`Error::ParameterMismatch`] if the plaintext is incompatible with this runtime's
-     * scheme.
-     */
-    pub(crate) fn encrypt_return_components_switched<P>(
-        &self,
-        val: P,
-        public_key: &PublicKey,
-        export_components: bool,
-        seed: Option<&[u64; 8]>,
-    ) -> Result<BFVEncryptionComponents>
-    where
-        P: TryIntoPlaintext + TypeName,
-    {
         let plaintext = val.try_into_plaintext(self.params())?;
         let plaintext_type = P::type_name();
-        self.encrypt_return_components_switched_internal(
-            &plaintext,
-            &plaintext_type,
-            public_key,
-            export_components,
-            seed,
-        )
+        self.encrypt_return_components_internal(&plaintext, &plaintext_type, public_key, Some(seed))
     }
 
-    pub(crate) fn encrypt_return_components_switched_internal(
+    pub(crate) fn encrypt_return_components_internal(
         &self,
         plaintext: &Plaintext,
         plaintext_type: &Type,
         public_key: &PublicKey,
-        export_components: bool,
         seed: Option<&[u64; 8]>,
     ) -> Result<BFVEncryptionComponents> {
         let fhe_data = self.runtime_data.unwrap_fhe();
         let (ciphertext, u, e, r) = match (&fhe_data.context, &plaintext.inner) {
             (Context::Seal(context), InnerPlaintext::Seal(inner_plain)) => {
                 let encryptor = Encryptor::with_public_key(context, &public_key.public_key.data)?;
-
-                let capacity = if export_components {
-                    inner_plain.len()
-                } else {
-                    0
+                let enc_fn = |pt: &SealPlaintext, _seed: Option<&[u64; 8]>| {
+                    #[cfg(feature = "deterministic")]
+                    if let Some(seed) = seed {
+                        encryptor.encrypt_return_components_deterministic(&pt, seed)
+                    } else {
+                        encryptor.encrypt_return_components(&pt)
+                    }
+                    #[cfg(not(feature = "deterministic"))]
+                    encryptor.encrypt_return_components(&pt)
                 };
+
+                let capacity = inner_plain.len();
+
                 let mut us = Vec::with_capacity(capacity);
                 let mut es = Vec::with_capacity(capacity);
                 let mut rs = Vec::with_capacity(capacity);
@@ -611,37 +670,28 @@ where
                 let ciphertexts = inner_plain
                     .iter()
                     .map(|p| {
-                        let ciphertext = if !export_components {
-                            encryptor.encrypt(p).map_err(Error::SealError)
-                        } else {
-                            let (ciphertext, u, e, r) = encrypt_function(&encryptor, p, seed)?;
+                        let (ciphertext, u, e, r) = enc_fn(p, seed)?;
 
-                            let r_context = WithContext {
-                                params: fhe_data.params.clone(),
-                                data: r,
-                            };
+                        let r_context = WithContext {
+                            params: fhe_data.params.clone(),
+                            data: r,
+                        };
 
-                            let r = Plaintext {
-                                data_type: plaintext_type.clone(),
-                                inner: InnerPlaintext::Seal(vec![r_context]),
-                            };
+                        let r = Plaintext {
+                            data_type: plaintext_type.clone(),
+                            inner: InnerPlaintext::Seal(vec![r_context]),
+                        };
 
-                            us.push(u);
-                            es.push(e);
-                            rs.push(r);
+                        us.push(u);
+                        es.push(e);
+                        rs.push(r);
 
-                            Ok(ciphertext)
-                        }?;
-
-                        Ok(ciphertext)
+                        Ok(WithContext {
+                            params: fhe_data.params.clone(),
+                            data: ciphertext,
+                        })
                     })
-                    .collect::<Result<Vec<SealCiphertext>>>()?
-                    .into_iter()
-                    .map(|c| WithContext {
-                        params: fhe_data.params.clone(),
-                        data: c,
-                    })
-                    .collect();
+                    .collect::<Result<Vec<_>>>()?;
 
                 (
                     Ciphertext {
@@ -664,6 +714,129 @@ where
             e,
             r,
         })
+    }
+
+    #[allow(dead_code)]
+    /**
+     * Encrypts the given [`FheType`](crate::FheType) symmetrically using the given private key,
+     * returning the ciphertext and the components used in encrypting the data.
+     *
+     * Returns [`Error::ParameterMismatch`] if the plaintext is incompatible
+     * with this runtime's scheme.
+     */
+    pub(crate) fn encrypt_symmetric_return_components<P>(
+        &self,
+        val: P,
+        private_key: &PrivateKey,
+    ) -> Result<BFVSymmetricEncryptionComponents>
+    where
+        P: TryIntoPlaintext + TypeName,
+    {
+        let plaintext = val.try_into_plaintext(self.params())?;
+        let plaintext_type = P::type_name();
+        self.encrypt_symmetric_return_components_internal(
+            &plaintext,
+            &plaintext_type,
+            private_key,
+            None,
+        )
+    }
+
+    /**
+     * DO NOT USE THIS FUNCTION IN PRODUCTION: IT PRODUCES DETERMINISTIC
+     * ENCRYPTIONS. IT IS INHERENTLY INSECURE, AND ONLY MEANT FOR TESTING OR
+     * DEMONSTRATION PURPOSES.
+     *
+     * Encrypts the given [`FheType`](crate::FheType) symmetrically using the given private key.
+     *
+     * Returns [`Error::ParameterMismatch`] if the plaintext is incompatible with this runtime's
+     * scheme.
+     */
+    #[cfg(feature = "deterministic")]
+    #[allow(dead_code)]
+    pub(crate) fn encrypt_symmetric_return_components_deterministic<P>(
+        &self,
+        val: P,
+        private_key: &PrivateKey,
+        seed: &[u64; 8],
+    ) -> Result<BFVSymmetricEncryptionComponents>
+    where
+        P: TryIntoPlaintext + TypeName,
+    {
+        let plaintext = val.try_into_plaintext(self.params())?;
+        let plaintext_type = P::type_name();
+        self.encrypt_symmetric_return_components_internal(
+            &plaintext,
+            &plaintext_type,
+            private_key,
+            Some(seed),
+        )
+    }
+
+    pub(crate) fn encrypt_symmetric_return_components_internal(
+        &self,
+        plaintext: &Plaintext,
+        plaintext_type: &Type,
+        private_key: &PrivateKey,
+        seed: Option<&[u64; 8]>,
+    ) -> Result<BFVSymmetricEncryptionComponents> {
+        let fhe_data = self.runtime_data.unwrap_fhe();
+        let (ciphertext, e, r) = match (&fhe_data.context, &plaintext.inner) {
+            (Context::Seal(context), InnerPlaintext::Seal(inner_plain)) => {
+                let encryptor = Encryptor::with_secret_key(context, &private_key.0.data)?;
+                let enc_fn = |pt: &SealPlaintext, _seed: Option<&[u64; 8]>| {
+                    #[cfg(feature = "deterministic")]
+                    if let Some(seed) = seed {
+                        encryptor.encrypt_symmetric_return_components_deterministic(&pt, seed)
+                    } else {
+                        encryptor.encrypt_symmetric_return_components(&pt)
+                    }
+                    #[cfg(not(feature = "deterministic"))]
+                    encryptor.encrypt_symmetric_return_components(&pt)
+                };
+
+                let capacity = inner_plain.len();
+                let mut es = Vec::with_capacity(capacity);
+                let mut rs = Vec::with_capacity(capacity);
+
+                let ciphertexts = inner_plain
+                    .iter()
+                    .map(|p| {
+                        let (ciphertext, e, r) = enc_fn(p, seed)?;
+
+                        let r_context = WithContext {
+                            params: fhe_data.params.clone(),
+                            data: r,
+                        };
+                        let r = Plaintext {
+                            data_type: plaintext_type.clone(),
+                            inner: InnerPlaintext::Seal(vec![r_context]),
+                        };
+                        es.push(e);
+                        rs.push(r);
+
+                        Ok(WithContext {
+                            params: fhe_data.params.clone(),
+                            data: ciphertext,
+                        })
+                    })
+                    .collect::<Result<Vec<_>>>()?;
+
+                (
+                    Ciphertext {
+                        data_type: Type {
+                            is_encrypted: true,
+                            ..plaintext_type.clone()
+                        },
+                        inner: InnerCiphertext::Seal(ciphertexts),
+                    },
+                    es,
+                    rs,
+                )
+            }
+        };
+
+        Ok(BFVSymmetricEncryptionComponents { ciphertext, e, r })
     }
 }
 
@@ -814,6 +987,7 @@ where
     /**
      * Verify that the given `proof` satisfies the given `program`.
      */
+    #[allow(unused)]
     pub(crate) fn verify_with_parameters<I>(
         &self,
         program: &CompiledZkpProgram,


### PR DESCRIPTION
On the outside, all this does is expose extra `encrypt_symmetric_*` methods wherever there were `encrypt_*` methods, on both the `Runtime` and the `LogProofBuilder`. Internally I've changed a few things
- Gotten rid of the `runtime::BfvEncryptionComponents`. This lived at the runtime level and contained the higher level plaintext and ciphertext types that are supposed to be agnostic to seal, however it also contained types specific to seal. And it kind of forced a wrapping and unwrapping of seal data, when logproof itself is already seal specific. So instead, just define and deal with types `AsymmetricComponents` and `SymmetricComponents` from the seal_fhe layer. The builder interacts with these as the runtime iterates over the inner plaintexts.
- Added a marker to the `seal_fhe::Encryptor` to track whether or not it supports sym/asym encryptions.

See https://github.com/Sunscreen-tech/SEAL/pull/8 for seal changes.