### PR TITLE
Disallow repeating linked inputs

### DIFF
--- a/examples/private_tx_linkedproof/src/main.rs
+++ b/examples/private_tx_linkedproof/src/main.rs
@@ -56,7 +56,7 @@ fn main() -> Result<()> {
     println!("Building linkedproof...");
     let lp = proof_builder
         .zkp_program(valid_tx_zkp)?
-        .linked_input(&tx_msg)
+        .linked_input(tx_msg)
         .public_input(balance)
         .build_linkedproof()?;
 

--- a/sunscreen/tests/linked.rs
+++ b/sunscreen/tests/linked.rs
@@ -69,7 +69,7 @@ mod linked_tests {
             let lp = proof_builder
                 .zkp_program(valid_transaction_zkp)
                 .unwrap()
-                .linked_input(&tx_msg)
+                .linked_input(tx_msg)
                 .public_input(BulletproofsField::from(balance))
                 .build_linkedproof()
                 .unwrap();
@@ -110,7 +110,7 @@ mod linked_tests {
             proof_builder
                 .zkp_program(valid_transaction_zkp)
                 .unwrap()
-                .linked_input(&tx_msg)
+                .linked_input(tx_msg)
                 .public_input(BulletproofsField::from(balance));
 
             let lp = proof_builder.build_linkedproof();
@@ -145,7 +145,7 @@ mod linked_tests {
             proof_builder
                 .zkp_program(is_eq_zkp)
                 .unwrap()
-                .linked_input(&val_msg)
+                .linked_input(val_msg)
                 .public_input(BulletproofsField::from(val));
 
             let lp = proof_builder.build_linkedproof().unwrap_or_else(|e| {
@@ -199,7 +199,7 @@ mod linked_tests {
             proof_builder
                 .zkp_program(is_eq_zkp)
                 .unwrap()
-                .linked_input(&x_msg)
+                .linked_input(x_msg)
                 .private_input(BulletproofsField::from(x_n))
                 .private_input(BulletproofsField::from(x_d));
 
@@ -246,8 +246,8 @@ mod linked_tests {
             proof_builder
                 .zkp_program(compare_signed_zkp)
                 .unwrap()
-                .linked_input(&x_msg)
-                .linked_input(&y_msg);
+                .linked_input(x_msg)
+                .linked_input(y_msg);
 
             let lp = proof_builder
                 .build_linkedproof()
@@ -297,8 +297,8 @@ mod linked_tests {
             proof_builder
                 .zkp_program(compare_rational_zkp)
                 .unwrap()
-                .linked_input(&x_msg)
-                .linked_input(&y_msg);
+                .linked_input(x_msg)
+                .linked_input(y_msg);
 
             let lp = proof_builder
                 .build_linkedproof()
@@ -350,8 +350,8 @@ mod linked_tests {
             proof_builder
                 .zkp_program(is_eq_zkp)
                 .unwrap()
-                .linked_input(&x_msg)
-                .linked_input(&y_msg)
+                .linked_input(x_msg)
+                .linked_input(y_msg)
                 .private_input(BulletproofsField::from(val));
 
             let lp = proof_builder.build_linkedproof().unwrap();
@@ -415,7 +415,7 @@ mod linked_tests {
                 let (_ct, msg) = proof_builder
                     .encrypt_and_link(&Signed::from(1), &public_key)
                     .unwrap();
-                proof_builder.linked_input(&msg);
+                proof_builder.linked_input(msg);
             }
             for _ in 0..num_private_inputs {
                 proof_builder.private_input(BulletproofsField::from(1));
@@ -454,8 +454,8 @@ mod linked_tests {
             .encrypt_and_link(&Unsigned64::from(1), &public_key)
             .unwrap();
         proof_builder
-            .linked_input(&signed_msg)
-            .linked_input(&unsigned_msg);
+            .linked_input(signed_msg)
+            .linked_input(unsigned_msg);
         let res = proof_builder.build_linkedproof();
         assert!(matches!(
             res,

--- a/sunscreen_runtime/src/builder.rs
+++ b/sunscreen_runtime/src/builder.rs
@@ -274,11 +274,22 @@ mod linked {
     }
 
     /// A [`Plaintext`] message that can be linked. Create this with [`LogProofBuilder::encrypt_and_link`].
-    #[derive(Debug, Clone)]
+    #[derive(Debug)]
     pub struct LinkedMessage {
         pub(crate) id: usize,
         pub(crate) message: Arc<LinkedPlaintextTyped>,
         pub(crate) len: usize,
+    }
+
+    impl LinkedMessage {
+        // Only allow cloning internally.
+        fn clone(&self) -> Self {
+            LinkedMessage {
+                id: self.id,
+                message: self.message.clone(),
+                len: self.len,
+            }
+        }
     }
 
     enum Message {
@@ -644,8 +655,8 @@ mod linked {
         /// Add a linked private input to the ZKP program.
         ///
         /// This method assumes that you've created the `message` argument with _this_ builder.
-        pub fn linked_input(&mut self, message: &LinkedMessage) -> &mut Self {
-            self.linked_inputs.push(message.clone());
+        pub fn linked_input(&mut self, message: LinkedMessage) -> &mut Self {
+            self.linked_inputs.push(message);
             self
         }
 


### PR DESCRIPTION
I didn't see a way to make this possible in logproof, so I'm disallowing it from the API.