### PR TITLE
Diverge link methods

### DIFF
--- a/examples/private_tx_linkedproof/src/main.rs
+++ b/examples/private_tx_linkedproof/src/main.rs
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
     let mut proof_builder = LogProofBuilder::new(&rt);
 
     println!("Encrypting and sharing transaction...");
-    let (_ct, tx_msg) = proof_builder.encrypt_and_link(&tx, &public_key)?;
+    let (_ct, tx_msg) = proof_builder.encrypt_returning_link(&tx, &public_key)?;
 
     println!("Building linkedproof...");
     let lp = proof_builder

--- a/sunscreen/src/linked.rs
+++ b/sunscreen/src/linked.rs
@@ -24,4 +24,6 @@
 //! encryption](crate::FheRuntime::encrypt), while also opting to _share_ a message with a linked
 //! ZKP program. Under the hood, we'll handle the complicated bits of generating a linear relation
 //! for SDLP and sharing the secrets with the [`zkp_program`](crate::zkp_program).
-pub use sunscreen_runtime::{LinkedProof, LogProofBuilder, Sdlp, Message, LinkedMessage, ExistingMessage, LinkWithZkp};
+pub use sunscreen_runtime::{
+    ExistingMessage, LinkWithZkp, LinkedMessage, LinkedProof, LogProofBuilder, Message, Sdlp,
+};

--- a/sunscreen/src/linked.rs
+++ b/sunscreen/src/linked.rs
@@ -24,4 +24,4 @@
 //! encryption](crate::FheRuntime::encrypt), while also opting to _share_ a message with a linked
 //! ZKP program. Under the hood, we'll handle the complicated bits of generating a linear relation
 //! for SDLP and sharing the secrets with the [`zkp_program`](crate::zkp_program).
-pub use sunscreen_runtime::{LinkedProof, LogProofBuilder, Sdlp};
+pub use sunscreen_runtime::{LinkedProof, LogProofBuilder, Sdlp, Message, LinkedMessage, ExistingMessage, LinkWithZkp};

--- a/sunscreen/tests/linked.rs
+++ b/sunscreen/tests/linked.rs
@@ -343,7 +343,7 @@ mod linked_tests {
                 .encrypt_and_link(&Signed::from(val), &public_key)
                 .unwrap();
             // proves same plaintext within SDLP
-            let _ct_x1 = proof_builder.encrypt_linked(&x_msg, &public_key).unwrap();
+            let _ct_x1 = proof_builder.encrypt_again(&x_msg, &public_key).unwrap();
             // proves same value within ZKP
             let (_ct_y, y_msg) = proof_builder
                 .encrypt_symmetric_and_link(&Signed::from(val), &private_key)

--- a/sunscreen/tests/linked.rs
+++ b/sunscreen/tests/linked.rs
@@ -63,7 +63,7 @@ mod linked_tests {
             let mut proof_builder = LogProofBuilder::new(&rt);
 
             let (_ct, tx_msg) = proof_builder
-                .encrypt_and_link(&Signed::from(tx), &public_key)
+                .encrypt_returning_link(&Signed::from(tx), &public_key)
                 .unwrap();
 
             println!("Performing linked proof");
@@ -106,7 +106,7 @@ mod linked_tests {
         for tx in [-1, balance + 1] {
             let mut proof_builder = LogProofBuilder::new(&rt);
             let (_ct, tx_msg) = proof_builder
-                .encrypt_and_link(&Signed::from(tx), &public_key)
+                .encrypt_returning_link(&Signed::from(tx), &public_key)
                 .unwrap();
             proof_builder
                 .zkp_program(valid_transaction_zkp)
@@ -141,7 +141,7 @@ mod linked_tests {
         for val in [3, 0, -3] {
             let mut proof_builder = LogProofBuilder::new(&rt);
             let (_ct, val_msg) = proof_builder
-                .encrypt_and_link(&Signed::from(val), &public_key)
+                .encrypt_returning_link(&Signed::from(val), &public_key)
                 .unwrap();
             proof_builder
                 .zkp_program(is_eq_zkp)
@@ -196,7 +196,9 @@ mod linked_tests {
             let x_d = rand::random::<i32>().saturating_abs().saturating_add(1) as i64;
             let x = Rational::from(Rational64::new_raw(x_n, x_d));
             let mut proof_builder = LogProofBuilder::new(&rt);
-            let (_ct, x_msg) = proof_builder.encrypt_and_link(&x, &public_key).unwrap();
+            let (_ct, x_msg) = proof_builder
+                .encrypt_returning_link(&x, &public_key)
+                .unwrap();
             proof_builder
                 .zkp_program(is_eq_zkp)
                 .unwrap()
@@ -240,9 +242,11 @@ mod linked_tests {
             let (x, y) = (Signed::from(x.min(y)), Signed::from(x.max(y)));
 
             let mut proof_builder = LogProofBuilder::new(&rt);
-            let (_ct, x_msg) = proof_builder.encrypt_and_link(&x, &public_key).unwrap();
+            let (_ct, x_msg) = proof_builder
+                .encrypt_returning_link(&x, &public_key)
+                .unwrap();
             let (_ct, y_msg) = proof_builder
-                .encrypt_symmetric_and_link(&y, &private_key)
+                .encrypt_symmetric_returning_link(&y, &private_key)
                 .unwrap();
             proof_builder
                 .zkp_program(compare_signed_zkp)
@@ -293,8 +297,12 @@ mod linked_tests {
             let (x, y) = (Rational::from(x.min(y)), Rational::from(x.max(y)));
 
             let mut proof_builder = LogProofBuilder::new(&rt);
-            let (_ct, x_msg) = proof_builder.encrypt_and_link(&x, &public_key).unwrap();
-            let (_ct, y_msg) = proof_builder.encrypt_and_link(&y, &public_key).unwrap();
+            let (_ct, x_msg) = proof_builder
+                .encrypt_returning_link(&x, &public_key)
+                .unwrap();
+            let (_ct, y_msg) = proof_builder
+                .encrypt_returning_link(&y, &public_key)
+                .unwrap();
             proof_builder
                 .zkp_program(compare_rational_zkp)
                 .unwrap()
@@ -340,13 +348,13 @@ mod linked_tests {
         for val in [3, 0, -3] {
             let mut proof_builder = LogProofBuilder::new(&rt);
             let (_ct_x, x_msg) = proof_builder
-                .encrypt_and_link(&Signed::from(val), &public_key)
+                .encrypt_returning_link(&Signed::from(val), &public_key)
                 .unwrap();
             // proves same plaintext within SDLP
-            let _ct_x1 = proof_builder.encrypt_again(&x_msg, &public_key).unwrap();
+            let _ct_x1 = proof_builder.encrypt_msg(&x_msg, &public_key).unwrap();
             // proves same value within ZKP
             let (_ct_y, y_msg) = proof_builder
-                .encrypt_symmetric_and_link(&Signed::from(val), &private_key)
+                .encrypt_symmetric_returning_link(&Signed::from(val), &private_key)
                 .unwrap();
             proof_builder
                 .zkp_program(is_eq_zkp)
@@ -414,7 +422,7 @@ mod linked_tests {
             proof_builder.zkp_program(is_eq_zkp).unwrap();
             for _ in 0..num_linked_inputs {
                 let (_ct, msg) = proof_builder
-                    .encrypt_and_link(&Signed::from(1), &public_key)
+                    .encrypt_returning_link(&Signed::from(1), &public_key)
                     .unwrap();
                 proof_builder.linked_input(msg);
             }
@@ -449,10 +457,10 @@ mod linked_tests {
         let mut proof_builder = LogProofBuilder::new(&rt);
         proof_builder.zkp_program(compare_signed_zkp).unwrap();
         let (_ct, signed_msg) = proof_builder
-            .encrypt_and_link(&Signed::from(1), &public_key)
+            .encrypt_returning_link(&Signed::from(1), &public_key)
             .unwrap();
         let (_ct, unsigned_msg) = proof_builder
-            .encrypt_and_link(&Unsigned64::from(1), &public_key)
+            .encrypt_returning_link(&Unsigned64::from(1), &public_key)
             .unwrap();
         proof_builder
             .linked_input(signed_msg)

--- a/sunscreen/tests/sdlp.rs
+++ b/sunscreen/tests/sdlp.rs
@@ -52,10 +52,10 @@ mod sdlp_tests {
         let mut logproof_builder = LogProofBuilder::new(&rt);
 
         let (_a1, linked_a) = logproof_builder
-            .encrypt_and_share(&Fractional::<64>::from(3.23), &public_key)
+            .encrypt_returning_msg(&Fractional::<64>::from(3.23), &public_key)
             .unwrap();
         let _a2 = logproof_builder
-            .encrypt_symmetric_again(&linked_a, &private_key)
+            .encrypt_symmetric_msg(&linked_a, &private_key)
             .unwrap();
         let _other = logproof_builder
             .encrypt(&Signed::from(2), &public_key)

--- a/sunscreen/tests/sdlp.rs
+++ b/sunscreen/tests/sdlp.rs
@@ -2,7 +2,7 @@
 mod sdlp_tests {
     use lazy_static::lazy_static;
     use logproof::rings::SealQ128_1024;
-    use sunscreen::types::bfv::{Signed, Unsigned64};
+    use sunscreen::types::bfv::{Fractional, Signed, Unsigned64};
     use sunscreen_fhe_program::SchemeType;
 
     use sunscreen_runtime::{FheRuntime, LogProofBuilder, Params};
@@ -52,13 +52,13 @@ mod sdlp_tests {
         let mut logproof_builder = LogProofBuilder::new(&rt);
 
         let (_a1, linked_a) = logproof_builder
-            .encrypt_and_link(&Signed::from(2), &public_key)
+            .encrypt_initial(&Fractional::<64>::from(3.23), &public_key)
             .unwrap();
         let _a2 = logproof_builder
-            .encrypt_symmetric_linked(&linked_a, &private_key)
+            .encrypt_symmetric_again(&linked_a, &private_key)
             .unwrap();
         let _other = logproof_builder
-            .encrypt(&Signed::from(3), &public_key)
+            .encrypt(&Signed::from(2), &public_key)
             .unwrap();
         let sdlp = logproof_builder.build_logproof().unwrap();
         sdlp.verify().unwrap();

--- a/sunscreen/tests/sdlp.rs
+++ b/sunscreen/tests/sdlp.rs
@@ -52,7 +52,7 @@ mod sdlp_tests {
         let mut logproof_builder = LogProofBuilder::new(&rt);
 
         let (_a1, linked_a) = logproof_builder
-            .encrypt_initial(&Fractional::<64>::from(3.23), &public_key)
+            .encrypt_and_share(&Fractional::<64>::from(3.23), &public_key)
             .unwrap();
         let _a2 = logproof_builder
             .encrypt_symmetric_again(&linked_a, &private_key)

--- a/sunscreen_runtime/src/builder.rs
+++ b/sunscreen_runtime/src/builder.rs
@@ -449,11 +449,12 @@ mod linked {
         }
 
         /// Encrypt a plaintext, adding the encryption statement to the proof and returning the
-        /// message to optionally be [encrypted again](`Self::encrypt_again`).
+        /// message to optionally be [encrypted again](`Self::encrypt_again`), that is, _shared_
+        /// with another proof statement.
         ///
         /// If you do not want to add the encryption statement to the proof, just use [the
         /// runtime](`crate::GenericRuntime::encrypt`) directly.
-        pub fn encrypt_initial<P>(
+        pub fn encrypt_and_share<P>(
             &mut self,
             message: &P,
             public_key: &'k PublicKey,
@@ -464,12 +465,13 @@ mod linked {
             self.encrypt_returning_msg(message, Key::Public(public_key), None)
         }
 
-        /// Encrypt a plaintext symmetrically, adding the encryption statement to the proof and
-        /// returning the message to optionally be [encrypted again](`Self::encrypt_again`).
+        /// Encrypt a plaintext, adding the encryption statement to the proof and returning the
+        /// message to optionally be [encrypted again](`Self::encrypt_again`), that is, _shared_
+        /// with another proof statement.
         ///
         /// If you do not want to add the encryption statement to the proof, just use [the
-        /// runtime](`crate::GenericRuntime::encrypt`) directly.
-        pub fn encrypt_symmetric_initial<P>(
+        /// runtime](`crate::GenericRuntime::encrypt_symmetric`) directly.
+        pub fn encrypt_symmetric_and_share<P>(
             &mut self,
             message: &P,
             private_key: &'k PrivateKey,
@@ -515,7 +517,7 @@ mod linked {
 
         /// Encrypt an existing message, adding the new encryption statement to the proof.
         ///
-        /// This method purposefully reveals that two ciphertexts enrypt the same underlying value. If
+        /// This method purposefully reveals that two ciphertexts encrypt the same underlying value. If
         /// this is not what you want, use [`Self::encrypt`].
         ///
         /// This method assumes that you've created the `message` argument with _this_ builder.
@@ -536,8 +538,8 @@ mod linked {
         /// Encrypt a linked message symmetrically, adding the new encryption statement to the
         /// proof.
         ///
-        /// This method purposefully reveals that two ciphertexts enrypt the same underlying value. If
-        /// this is not what you want, use [`Self::encrypt`].
+        /// This method purposefully reveals that two ciphertexts encrypt the same underlying value. If
+        /// this is not what you want, use [`Self::encrypt_symmetric`].
         ///
         /// This method assumes that you've created the `message` argument with _this_ builder.
         pub fn encrypt_symmetric_again<E: ExistingMessage>(


### PR DESCRIPTION
I had merged the notions of referencing an existing message in SDLP and in ZKP. This doesn't make sense and also imposes unnecessarily limitations. This PR separates the two notions.

# api
Essentially the API looks like this (with each one also having a corresponding symmetric version):

```rust
impl Builder {
    /// Encrypt a plaintext, adding the encryption statement to the proof.
    pub fn encrypt<P>(&mut self, message: &P, public_key: &'k PublicKey) -> Result<Ciphertext>
        where
            P: TryIntoPlaintext + TypeName;

    /// Encrypt a plaintext, adding the encryption statement to the proof and returning the
    /// message to optionally be [encrypted again](`Self::encrypt_again`), that is, _shared_
    /// with another proof statement.
    pub fn encrypt_and_share<P>(&mut self, message: &P, public_key: &'k PublicKey) -> Result<(Ciphertext, Message)>
        where
            P: TryIntoPlaintext + TypeName;

    /// Encrypt a plaintext intended for linking.
    ///
    /// The returned `LinkedMessage` can be used:
    /// 1. to add an encryption statement of ciphertext equality to the proof (see [`Self::encrypt_again`]).
    /// 2. as a linked input to a ZKP program (see [`Self::linked_input`]).
    pub fn encrypt_and_link<P>(&mut self, message: &P, public_key: &'k PublicKey) -> Result<(Ciphertext, LinkedMessage)>
        where
            P: LinkWithZkp + TryIntoPlaintext + TypeName;

    /// Encrypt an existing message, adding the new encryption statement to the proof.
    ///
    /// This method purposefully reveals that two ciphertexts encrypt the same underlying value. If
    /// this is not what you want, use [`Self::encrypt`].
    pub fn encrypt_again<E>(&mut self, message: &E, public_key: &'k PublicKey) -> Result<Ciphertext>
        where
            E: ExistingMessage;
}
```

# other ideas
I played with some other ideas, like using a singular `Message<T = ()>` and `type LinkedMessage = Message<Link>` rather than the sealed `ExistingMessage` trait. We do use that pattern elsewhere so it wouldn't be inconsistent to do so, but in the end I thought above was simpler. I also considered always returning a `Message` from these methods, where `Message` can be converted into a ciphertext, but again thought it was not as clear as the above.

Let me know what you think regarding `ExistingMessage` vs `Message<T>`, I could go either way.