### PR TITLE
Rweber/tfhe mem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,6 +39,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aligned-vec"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa90d7ce82d4be67b64039a3d588d38dbcc6736577de4a847025ce5b0c468d1"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,12 +1639,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-list"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4dacf969043dc69f1f731b5042eb05e030d264bcf34f2242889fcbdc7a65f06"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3086,9 +3089,9 @@ dependencies = [
 name = "sunscreen_tfhe"
 version = "0.1.0"
 dependencies = [
+ "aligned-vec",
  "bytemuck",
  "criterion 0.5.1",
- "linked-list",
  "logproof",
  "merlin",
  "num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ lto = false
 codegen-units = 16
 
 [workspace.dependencies]
+aligned-vec = { version = "0.5.0", features = ["serde"] }
 bytemuck = "1.13.0"
 lazy_static = "1.4.0"
 metal = "0.26.0"

--- a/sunscreen_tfhe/Cargo.toml
+++ b/sunscreen_tfhe/Cargo.toml
@@ -16,9 +16,8 @@ readme = "crates-io.md"
 
 
 [dependencies]
+aligned-vec = { workspace = true }
 bytemuck = { workspace = true }
-# TODO: Remove when Rust stabilizes Cursor API
-linked-list = "0.0.3"
 logproof = { workspace = true, optional = true }
 num = { workspace = true }
 paste = { workspace = true }

--- a/sunscreen_tfhe/src/dst.rs
+++ b/sunscreen_tfhe/src/dst.rs
@@ -15,7 +15,7 @@ macro_rules! avec_from_iter {
 macro_rules! avec_from_slice {
     ($slice:expr) => {
         aligned_vec::AVec::from_slice(crate::scratch::SIMD_ALIGN, $slice)
-    }
+    };
 }
 
 macro_rules! dst {

--- a/sunscreen_tfhe/src/dst.rs
+++ b/sunscreen_tfhe/src/dst.rs
@@ -6,6 +6,12 @@ macro_rules! avec {
     };
 }
 
+macro_rules! avec_from_iter {
+    ($iter:expr) => {
+        aligned_vec::AVec::from_iter(crate::scratch::SIMD_ALIGN, $iter)
+    };
+}
+
 macro_rules! dst {
     ($(#[$meta:meta])* $t:ty, $ref_t:ty, $wrapper:ty, ($($derive:ident),* $(,)? ), ($($t_bounds:ty),* $(,)? )) => {
         paste::paste! {

--- a/sunscreen_tfhe/src/dst.rs
+++ b/sunscreen_tfhe/src/dst.rs
@@ -12,6 +12,12 @@ macro_rules! avec_from_iter {
     };
 }
 
+macro_rules! avec_from_slice {
+    ($slice:expr) => {
+        aligned_vec::AVec::from_slice(crate::scratch::SIMD_ALIGN, $slice)
+    }
+}
+
 macro_rules! dst {
     ($(#[$meta:meta])* $t:ty, $ref_t:ty, $wrapper:ty, ($($derive:ident),* $(,)? ), ($($t_bounds:ty),* $(,)? )) => {
         paste::paste! {

--- a/sunscreen_tfhe/src/entities/bivariate_lookup_table.rs
+++ b/sunscreen_tfhe/src/entities/bivariate_lookup_table.rs
@@ -5,7 +5,7 @@ use crate::{
     dst::{FromMutSlice, FromSlice, OverlaySize},
     entities::PolynomialRef,
     ops::{bootstrapping::generate_bivariate_lut, encryption::trivially_encrypt_glwe_ciphertext},
-    scratch::allocate_scratch_ref,
+    scratch::{allocate_scratch_ref, SIMD_ALIGN},
     CarryBits, GlweDef, GlweDimension, PlaintextBits, Torus, TorusOps,
 };
 
@@ -43,7 +43,7 @@ impl<S: TorusOps> BivariateLookupTable<S> {
         F: Fn(u64, u64) -> u64,
     {
         let mut lut = BivariateLookupTable {
-            data: vec![Torus::zero(); BivariateLookupTableRef::<S>::size(glwe.dim)],
+            data: avec!(Torus::zero(); BivariateLookupTableRef::<S>::size(glwe.dim))
         };
 
         lut.fill_trivial_from_fn(map, glwe, plaintext_bits, carry_bits);

--- a/sunscreen_tfhe/src/entities/bivariate_lookup_table.rs
+++ b/sunscreen_tfhe/src/entities/bivariate_lookup_table.rs
@@ -5,7 +5,7 @@ use crate::{
     dst::{FromMutSlice, FromSlice, OverlaySize},
     entities::PolynomialRef,
     ops::{bootstrapping::generate_bivariate_lut, encryption::trivially_encrypt_glwe_ciphertext},
-    scratch::{allocate_scratch_ref, SIMD_ALIGN},
+    scratch::{allocate_scratch_ref},
     CarryBits, GlweDef, GlweDimension, PlaintextBits, Torus, TorusOps,
 };
 

--- a/sunscreen_tfhe/src/entities/bivariate_lookup_table.rs
+++ b/sunscreen_tfhe/src/entities/bivariate_lookup_table.rs
@@ -43,7 +43,7 @@ impl<S: TorusOps> BivariateLookupTable<S> {
         F: Fn(u64, u64) -> u64,
     {
         let mut lut = BivariateLookupTable {
-            data: avec!(Torus::zero(); BivariateLookupTableRef::<S>::size(glwe.dim))
+            data: avec!(Torus::zero(); BivariateLookupTableRef::<S>::size(glwe.dim)),
         };
 
         lut.fill_trivial_from_fn(map, glwe, plaintext_bits, carry_bits);

--- a/sunscreen_tfhe/src/entities/bivariate_lookup_table.rs
+++ b/sunscreen_tfhe/src/entities/bivariate_lookup_table.rs
@@ -5,7 +5,7 @@ use crate::{
     dst::{FromMutSlice, FromSlice, OverlaySize},
     entities::PolynomialRef,
     ops::{bootstrapping::generate_bivariate_lut, encryption::trivially_encrypt_glwe_ciphertext},
-    scratch::{allocate_scratch_ref},
+    scratch::allocate_scratch_ref,
     CarryBits, GlweDef, GlweDimension, PlaintextBits, Torus, TorusOps,
 };
 

--- a/sunscreen_tfhe/src/entities/blind_rotation_shift.rs
+++ b/sunscreen_tfhe/src/entities/blind_rotation_shift.rs
@@ -5,7 +5,7 @@ use crate::{
     dst::{NoWrapper, OverlaySize}, entities::{
         GgswCiphertextFftIterator, GgswCiphertextFftIteratorMut, GgswCiphertextFftRef,
         GgswCiphertextIterator, GgswCiphertextIteratorMut, GgswCiphertextRef,
-    }, scratch::SIMD_ALIGN, GlweDef, GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps
+    }, GlweDef, GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps
 };
 
 dst! {

--- a/sunscreen_tfhe/src/entities/blind_rotation_shift.rs
+++ b/sunscreen_tfhe/src/entities/blind_rotation_shift.rs
@@ -2,10 +2,12 @@ use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::{NoWrapper, OverlaySize}, entities::{
+    dst::{NoWrapper, OverlaySize},
+    entities::{
         GgswCiphertextFftIterator, GgswCiphertextFftIteratorMut, GgswCiphertextFftRef,
         GgswCiphertextIterator, GgswCiphertextIteratorMut, GgswCiphertextRef,
-    }, GlweDef, GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps
+    },
+    GlweDef, GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps,
 };
 
 dst! {
@@ -38,7 +40,7 @@ impl<S: TorusOps> BlindRotationShift<S> {
     pub fn new(params: &GlweDef, radix: &RadixDecomposition) -> Self {
         let len = BlindRotationShiftRef::<S>::size((params.dim, radix.count));
 
-        Self {            
+        Self {
             data: avec![Torus::zero(); len],
         }
     }

--- a/sunscreen_tfhe/src/entities/blind_rotation_shift.rs
+++ b/sunscreen_tfhe/src/entities/blind_rotation_shift.rs
@@ -2,12 +2,10 @@ use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::{NoWrapper, OverlaySize},
-    entities::{
+    dst::{NoWrapper, OverlaySize}, entities::{
         GgswCiphertextFftIterator, GgswCiphertextFftIteratorMut, GgswCiphertextFftRef,
         GgswCiphertextIterator, GgswCiphertextIteratorMut, GgswCiphertextRef,
-    },
-    GlweDef, GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps,
+    }, scratch::SIMD_ALIGN, GlweDef, GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps
 };
 
 dst! {
@@ -40,8 +38,8 @@ impl<S: TorusOps> BlindRotationShift<S> {
     pub fn new(params: &GlweDef, radix: &RadixDecomposition) -> Self {
         let len = BlindRotationShiftRef::<S>::size((params.dim, radix.count));
 
-        Self {
-            data: vec![Torus::zero(); len],
+        Self {            
+            data: avec![Torus::zero(); len],
         }
     }
 }
@@ -94,7 +92,7 @@ impl BlindRotationShiftFft<Complex<f64>> {
         let len = BlindRotationShiftFftRef::size((params.dim, radix.count));
 
         Self {
-            data: vec![Complex::zero(); len],
+            data: avec![Complex::zero(); len],
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/bootstrap_key.rs
+++ b/sunscreen_tfhe/src/entities/bootstrap_key.rs
@@ -2,11 +2,13 @@ use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::{NoWrapper, OverlaySize}, entities::{
+    dst::{NoWrapper, OverlaySize},
+    entities::{
         GgswCiphertextFftIterator, GgswCiphertextFftIteratorMut, GgswCiphertextFftRef,
         GgswCiphertextIterator, GgswCiphertextIteratorMut, GgswCiphertextRef,
         ParallelGgswCiphertextIterator, ParallelGgswCiphertextIteratorMut,
-    }, GlweDef, GlweDimension, LweDef, LweDimension, RadixCount, RadixDecomposition, Torus, TorusOps
+    },
+    GlweDef, GlweDimension, LweDef, LweDimension, RadixCount, RadixDecomposition, Torus, TorusOps,
 };
 
 dst! {

--- a/sunscreen_tfhe/src/entities/bootstrap_key.rs
+++ b/sunscreen_tfhe/src/entities/bootstrap_key.rs
@@ -2,13 +2,11 @@ use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::{NoWrapper, OverlaySize},
-    entities::{
+    dst::{NoWrapper, OverlaySize}, entities::{
         GgswCiphertextFftIterator, GgswCiphertextFftIteratorMut, GgswCiphertextFftRef,
         GgswCiphertextIterator, GgswCiphertextIteratorMut, GgswCiphertextRef,
         ParallelGgswCiphertextIterator, ParallelGgswCiphertextIteratorMut,
-    },
-    GlweDef, GlweDimension, LweDef, LweDimension, RadixCount, RadixDecomposition, Torus, TorusOps,
+    }, scratch::SIMD_ALIGN, GlweDef, GlweDimension, LweDef, LweDimension, RadixCount, RadixDecomposition, Torus, TorusOps
 };
 
 dst! {
@@ -42,7 +40,7 @@ impl<S: TorusOps> BootstrapKey<S> {
         let len = BootstrapKeyRef::<S>::size((lwe_params.dim, glwe_params.dim, radix.count));
 
         Self {
-            data: vec![Torus::zero(); len],
+            data: avec![Torus::zero(); len],
         }
     }
 }
@@ -145,7 +143,7 @@ impl BootstrapKeyFft<Complex<f64>> {
         let len = BootstrapKeyFftRef::size((lwe_params.dim, glwe_params.dim, radix.count));
 
         Self {
-            data: vec![Complex::zero(); len],
+            data: avec![Complex::zero(); len],
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/bootstrap_key.rs
+++ b/sunscreen_tfhe/src/entities/bootstrap_key.rs
@@ -6,7 +6,7 @@ use crate::{
         GgswCiphertextFftIterator, GgswCiphertextFftIteratorMut, GgswCiphertextFftRef,
         GgswCiphertextIterator, GgswCiphertextIteratorMut, GgswCiphertextRef,
         ParallelGgswCiphertextIterator, ParallelGgswCiphertextIteratorMut,
-    }, scratch::SIMD_ALIGN, GlweDef, GlweDimension, LweDef, LweDimension, RadixCount, RadixDecomposition, Torus, TorusOps
+    }, GlweDef, GlweDimension, LweDef, LweDimension, RadixCount, RadixDecomposition, Torus, TorusOps
 };
 
 dst! {

--- a/sunscreen_tfhe/src/entities/circuit_bootstrapping_private_keyswitch_keys.rs
+++ b/sunscreen_tfhe/src/entities/circuit_bootstrapping_private_keyswitch_keys.rs
@@ -44,7 +44,7 @@ impl<S: TorusOps> CircuitBootstrappingKeyswitchKeys<S> {
         ));
 
         Self {
-            data: vec![Torus::zero(); len],
+            data: avec![Torus::zero(); len],
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/ggsw_ciphertext.rs
+++ b/sunscreen_tfhe/src/entities/ggsw_ciphertext.rs
@@ -1,10 +1,9 @@
-use aligned_vec::AVec;
 use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::OverlaySize, ops::ciphertext::external_product_ggsw_glwe, scratch::SIMD_ALIGN, GlweDef,
-    GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps,
+    dst::OverlaySize, ops::ciphertext::external_product_ggsw_glwe, GlweDef, GlweDimension,
+    RadixCount, RadixDecomposition, Torus, TorusOps,
 };
 
 use super::{
@@ -54,7 +53,7 @@ where
         assert_eq!(data.len(), elems);
 
         Self {
-            data: avec_from_slice!(data)
+            data: avec_from_slice!(data),
         }
     }
 

--- a/sunscreen_tfhe/src/entities/ggsw_ciphertext.rs
+++ b/sunscreen_tfhe/src/entities/ggsw_ciphertext.rs
@@ -3,7 +3,8 @@ use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::OverlaySize, ops::ciphertext::external_product_ggsw_glwe, scratch::SIMD_ALIGN, GlweDef, GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps
+    dst::OverlaySize, ops::ciphertext::external_product_ggsw_glwe, scratch::SIMD_ALIGN, GlweDef,
+    GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps,
 };
 
 use super::{

--- a/sunscreen_tfhe/src/entities/ggsw_ciphertext.rs
+++ b/sunscreen_tfhe/src/entities/ggsw_ciphertext.rs
@@ -1,9 +1,9 @@
+use aligned_vec::AVec;
 use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::OverlaySize, ops::ciphertext::external_product_ggsw_glwe, GlweDef, GlweDimension,
-    RadixCount, RadixDecomposition, Torus, TorusOps,
+    dst::OverlaySize, ops::ciphertext::external_product_ggsw_glwe, scratch::SIMD_ALIGN, GlweDef, GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps
 };
 
 use super::{
@@ -42,7 +42,7 @@ where
         let elems = GgswCiphertextRef::<S>::size((params.dim, radix.count));
 
         Self {
-            data: vec![Torus::zero(); elems],
+            data: avec![Torus::zero(); elems],
         }
     }
 
@@ -53,7 +53,7 @@ where
         assert_eq!(data.len(), elems);
 
         Self {
-            data: data.to_vec(),
+            data: AVec::from_slice(SIMD_ALIGN, data),
         }
     }
 

--- a/sunscreen_tfhe/src/entities/ggsw_ciphertext.rs
+++ b/sunscreen_tfhe/src/entities/ggsw_ciphertext.rs
@@ -54,7 +54,7 @@ where
         assert_eq!(data.len(), elems);
 
         Self {
-            data: AVec::from_slice(SIMD_ALIGN, data),
+            data: avec_from_slice!(data)
         }
     }
 

--- a/sunscreen_tfhe/src/entities/ggsw_ciphertext_fft.rs
+++ b/sunscreen_tfhe/src/entities/ggsw_ciphertext_fft.rs
@@ -34,7 +34,7 @@ impl GgswCiphertextFft<Complex<f64>> {
         let len = GgswCiphertextFftRef::size((params.dim, radix.count));
 
         GgswCiphertextFft {
-            data: vec![Complex::zero(); len],
+            data: avec![Complex::zero(); len],
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/glwe_ciphertext.rs
+++ b/sunscreen_tfhe/src/entities/glwe_ciphertext.rs
@@ -74,7 +74,7 @@ where
         assert_eq!(data.len(), GlweCiphertextRef::<S>::size(params.dim));
 
         GlweCiphertext {
-            data: AVec::from_iter(SIMD_ALIGN, data.iter().map(|x| Torus::from(*x))),
+            data: avec_from_iter!(data.iter().map(|x| Torus::from(*x))),
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/glwe_ciphertext.rs
+++ b/sunscreen_tfhe/src/entities/glwe_ciphertext.rs
@@ -1,12 +1,9 @@
+use aligned_vec::AVec;
 use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::{FromMutSlice, FromSlice, OverlaySize},
-    entities::GgswCiphertextRef,
-    macros::{impl_binary_op, impl_unary_op},
-    ops::ciphertext::external_product_ggsw_glwe,
-    GlweDef, GlweDimension, RadixDecomposition, Torus, TorusOps,
+    dst::{FromMutSlice, FromSlice, OverlaySize}, entities::GgswCiphertextRef, macros::{impl_binary_op, impl_unary_op}, ops::ciphertext::external_product_ggsw_glwe, scratch::SIMD_ALIGN, GlweDef, GlweDimension, RadixDecomposition, Torus, TorusOps
 };
 
 use super::{
@@ -51,9 +48,7 @@ where
 
         let len = GlweCiphertextRef::<S>::size(params.dim);
 
-        let data = (0..len).map(|_| Torus::<S>::zero()).collect::<Vec<_>>();
-
-        GlweCiphertext { data }
+        GlweCiphertext { data: avec![Torus::zero(); len] }
     }
 
     /// Computes the external product of a GLWE ciphertext and a GGSW ciphertext.
@@ -72,10 +67,11 @@ where
         assert_eq!(data.len(), GlweCiphertextRef::<S>::size(params.dim));
 
         GlweCiphertext {
-            data: data
+            data: AVec::from_iter(SIMD_ALIGN, 
+                data
                 .iter()
                 .map(|x| Torus::from(*x))
-                .collect::<Vec<Torus<S>>>(),
+            ),
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/glwe_ciphertext.rs
+++ b/sunscreen_tfhe/src/entities/glwe_ciphertext.rs
@@ -3,7 +3,12 @@ use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::{FromMutSlice, FromSlice, OverlaySize}, entities::GgswCiphertextRef, macros::{impl_binary_op, impl_unary_op}, ops::ciphertext::external_product_ggsw_glwe, scratch::SIMD_ALIGN, GlweDef, GlweDimension, RadixDecomposition, Torus, TorusOps
+    dst::{FromMutSlice, FromSlice, OverlaySize},
+    entities::GgswCiphertextRef,
+    macros::{impl_binary_op, impl_unary_op},
+    ops::ciphertext::external_product_ggsw_glwe,
+    scratch::SIMD_ALIGN,
+    GlweDef, GlweDimension, RadixDecomposition, Torus, TorusOps,
 };
 
 use super::{
@@ -48,7 +53,9 @@ where
 
         let len = GlweCiphertextRef::<S>::size(params.dim);
 
-        GlweCiphertext { data: avec![Torus::zero(); len] }
+        GlweCiphertext {
+            data: avec![Torus::zero(); len],
+        }
     }
 
     /// Computes the external product of a GLWE ciphertext and a GGSW ciphertext.
@@ -67,11 +74,7 @@ where
         assert_eq!(data.len(), GlweCiphertextRef::<S>::size(params.dim));
 
         GlweCiphertext {
-            data: AVec::from_iter(SIMD_ALIGN, 
-                data
-                .iter()
-                .map(|x| Torus::from(*x))
-            ),
+            data: AVec::from_iter(SIMD_ALIGN, data.iter().map(|x| Torus::from(*x))),
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/glwe_ciphertext.rs
+++ b/sunscreen_tfhe/src/entities/glwe_ciphertext.rs
@@ -1,4 +1,4 @@
-use aligned_vec::AVec;
+
 use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +7,6 @@ use crate::{
     entities::GgswCiphertextRef,
     macros::{impl_binary_op, impl_unary_op},
     ops::ciphertext::external_product_ggsw_glwe,
-    scratch::SIMD_ALIGN,
     GlweDef, GlweDimension, RadixDecomposition, Torus, TorusOps,
 };
 

--- a/sunscreen_tfhe/src/entities/glwe_ciphertext.rs
+++ b/sunscreen_tfhe/src/entities/glwe_ciphertext.rs
@@ -1,4 +1,3 @@
-
 use num::{Complex, Zero};
 use serde::{Deserialize, Serialize};
 

--- a/sunscreen_tfhe/src/entities/glwe_ciphertext_fft.rs
+++ b/sunscreen_tfhe/src/entities/glwe_ciphertext_fft.rs
@@ -34,7 +34,7 @@ impl GlweCiphertextFft<Complex<f64>> {
         let len = GlweCiphertextFftRef::size(params.dim);
 
         Self {
-            data: vec![Complex::zero(); len],
+            data: avec![Complex::zero(); len],
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/glwe_keyswitch_key.rs
+++ b/sunscreen_tfhe/src/entities/glwe_keyswitch_key.rs
@@ -44,7 +44,7 @@ where
         let elems = GlweKeyswitchKeyRef::<S>::size((params.dim, radix.count));
 
         Self {
-            data: vec![Torus::zero(); elems],
+            data: avec![Torus::zero(); elems],
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/glwe_secret_key.rs
+++ b/sunscreen_tfhe/src/entities/glwe_secret_key.rs
@@ -2,9 +2,15 @@ use aligned_vec::AVec;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::{FromSlice, NoWrapper, OverlaySize}, entities::GgswCiphertext, macros::{impl_binary_op, impl_unary_op}, ops::encryption::{
+    dst::{FromSlice, NoWrapper, OverlaySize},
+    entities::GgswCiphertext,
+    macros::{impl_binary_op, impl_unary_op},
+    ops::encryption::{
         decrypt_glwe_ciphertext, encrypt_ggsw_ciphertext, encrypt_glwe_ciphertext_secret,
-    }, rand::{binary, uniform_torus}, scratch::SIMD_ALIGN, GlweDef, GlweDimension, PlaintextBits, RadixDecomposition, Torus, TorusOps
+    },
+    rand::{binary, uniform_torus},
+    scratch::SIMD_ALIGN,
+    GlweDef, GlweDimension, PlaintextBits, RadixDecomposition, Torus, TorusOps,
 };
 
 use super::{
@@ -51,9 +57,7 @@ where
         let len = GlweSecretKeyRef::<S>::size(params.dim);
 
         GlweSecretKey {
-            data: AVec::from_iter(SIMD_ALIGN, (0..len)
-                .map(|_| torus_element_generator())
-            ),
+            data: AVec::from_iter(SIMD_ALIGN, (0..len).map(|_| torus_element_generator())),
         }
     }
 
@@ -209,11 +213,13 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(SIMD_ALIGN, sk
-            .data
-            .iter()
-            .zip(sk2.data.iter())
-            .map(|(a, b)| a.wrapping_add(b)));
+        let sk3_expected = AVec::from_iter(
+            SIMD_ALIGN,
+            sk.data
+                .iter()
+                .zip(sk2.data.iter())
+                .map(|(a, b)| a.wrapping_add(b)),
+        );
 
         let sk3 = sk + sk2;
 
@@ -227,11 +233,13 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let mut sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk2_expected = AVec::from_iter(SIMD_ALIGN, sk
-            .data
-            .iter()
-            .zip(sk2.data.iter())
-            .map(|(a, b)| a.wrapping_add(b)));
+        let sk2_expected = AVec::from_iter(
+            SIMD_ALIGN,
+            sk.data
+                .iter()
+                .zip(sk2.data.iter())
+                .map(|(a, b)| a.wrapping_add(b)),
+        );
 
         sk2 += sk;
 
@@ -245,11 +253,12 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(SIMD_ALIGN, sk
-            .data
-            .iter()
-            .zip(sk2.data.iter())
-            .map(|(a, b)| a.wrapping_add(b))
+        let sk3_expected = AVec::from_iter(
+            SIMD_ALIGN,
+            sk.data
+                .iter()
+                .zip(sk2.data.iter())
+                .map(|(a, b)| a.wrapping_add(b)),
         );
 
         let sk3 = sk.as_ref() + sk2.as_ref();
@@ -264,11 +273,12 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(SIMD_ALIGN, sk
-            .data
-            .iter()
-            .zip(sk2.data.iter())
-            .map(|(a, b)| a.wrapping_add(b))
+        let sk3_expected = AVec::from_iter(
+            SIMD_ALIGN,
+            sk.data
+                .iter()
+                .zip(sk2.data.iter())
+                .map(|(a, b)| a.wrapping_add(b)),
         );
 
         let sk3 = sk.wrapping_add(&sk2);
@@ -285,11 +295,12 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(SIMD_ALIGN, sk
-            .data
-            .iter()
-            .zip(sk2.data.iter())
-            .map(|(a, b)| a.wrapping_sub(b))
+        let sk3_expected = AVec::from_iter(
+            SIMD_ALIGN,
+            sk.data
+                .iter()
+                .zip(sk2.data.iter())
+                .map(|(a, b)| a.wrapping_sub(b)),
         );
 
         let sk3 = sk - sk2;
@@ -304,11 +315,12 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let mut sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk2_expected = AVec::from_iter(SIMD_ALIGN, sk2
-            .data
-            .iter()
-            .zip(sk.data.iter())
-            .map(|(a, b)| a.wrapping_sub(b))
+        let sk2_expected = AVec::from_iter(
+            SIMD_ALIGN,
+            sk2.data
+                .iter()
+                .zip(sk.data.iter())
+                .map(|(a, b)| a.wrapping_sub(b)),
         );
 
         sk2 -= sk;
@@ -323,11 +335,13 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(SIMD_ALIGN, sk
-            .data
-            .iter()
-            .zip(sk2.data.iter())
-            .map(|(a, b)| a.wrapping_sub(b)));
+        let sk3_expected = AVec::from_iter(
+            SIMD_ALIGN,
+            sk.data
+                .iter()
+                .zip(sk2.data.iter())
+                .map(|(a, b)| a.wrapping_sub(b)),
+        );
 
         let sk3 = sk.as_ref() - sk2.as_ref();
 
@@ -341,11 +355,12 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(SIMD_ALIGN, sk
-            .data
-            .iter()
-            .zip(sk2.data.iter())
-            .map(|(a, b)| a.wrapping_sub(b))
+        let sk3_expected = AVec::from_iter(
+            SIMD_ALIGN,
+            sk.data
+                .iter()
+                .zip(sk2.data.iter())
+                .map(|(a, b)| a.wrapping_sub(b)),
         );
 
         let sk3 = sk.wrapping_sub(&sk2);

--- a/sunscreen_tfhe/src/entities/glwe_secret_key.rs
+++ b/sunscreen_tfhe/src/entities/glwe_secret_key.rs
@@ -1,4 +1,3 @@
-
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -211,12 +210,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = avec_from_iter!(
-            sk.data
-                .iter()
-                .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_add(b))
-        );
+        let sk3_expected = avec_from_iter!(sk
+            .data
+            .iter()
+            .zip(sk2.data.iter())
+            .map(|(a, b)| a.wrapping_add(b)));
 
         let sk3 = sk + sk2;
 
@@ -230,12 +228,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let mut sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk2_expected = avec_from_iter!(
-            sk.data
-                .iter()
-                .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_add(b))
-        );
+        let sk2_expected = avec_from_iter!(sk
+            .data
+            .iter()
+            .zip(sk2.data.iter())
+            .map(|(a, b)| a.wrapping_add(b)));
 
         sk2 += sk;
 
@@ -249,12 +246,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = avec_from_iter!(
-            sk.data
-                .iter()
-                .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_add(b))
-        );
+        let sk3_expected = avec_from_iter!(sk
+            .data
+            .iter()
+            .zip(sk2.data.iter())
+            .map(|(a, b)| a.wrapping_add(b)));
 
         let sk3 = sk.as_ref() + sk2.as_ref();
 
@@ -268,12 +264,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = avec_from_iter!(
-            sk.data
-                .iter()
-                .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_add(b))
-        );
+        let sk3_expected = avec_from_iter!(sk
+            .data
+            .iter()
+            .zip(sk2.data.iter())
+            .map(|(a, b)| a.wrapping_add(b)));
 
         let sk3 = sk.wrapping_add(&sk2);
 
@@ -289,12 +284,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = avec_from_iter!(
-            sk.data
-                .iter()
-                .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_sub(b))
-        );
+        let sk3_expected = avec_from_iter!(sk
+            .data
+            .iter()
+            .zip(sk2.data.iter())
+            .map(|(a, b)| a.wrapping_sub(b)));
 
         let sk3 = sk - sk2;
 
@@ -308,12 +302,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let mut sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk2_expected = avec_from_iter!(
-            sk2.data
-                .iter()
-                .zip(sk.data.iter())
-                .map(|(a, b)| a.wrapping_sub(b))
-        );
+        let sk2_expected = avec_from_iter!(sk2
+            .data
+            .iter()
+            .zip(sk.data.iter())
+            .map(|(a, b)| a.wrapping_sub(b)));
 
         sk2 -= sk;
 
@@ -327,12 +320,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = avec_from_iter!(
-            sk.data
-                .iter()
-                .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_sub(b))
-        );
+        let sk3_expected = avec_from_iter!(sk
+            .data
+            .iter()
+            .zip(sk2.data.iter())
+            .map(|(a, b)| a.wrapping_sub(b)));
 
         let sk3 = sk.as_ref() - sk2.as_ref();
 
@@ -346,12 +338,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = avec_from_iter!(
-            sk.data
-                .iter()
-                .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_sub(b))
-        );
+        let sk3_expected = avec_from_iter!(sk
+            .data
+            .iter()
+            .zip(sk2.data.iter())
+            .map(|(a, b)| a.wrapping_sub(b)));
 
         let sk3 = sk.wrapping_sub(&sk2);
 

--- a/sunscreen_tfhe/src/entities/glwe_secret_key.rs
+++ b/sunscreen_tfhe/src/entities/glwe_secret_key.rs
@@ -57,7 +57,7 @@ where
         let len = GlweSecretKeyRef::<S>::size(params.dim);
 
         GlweSecretKey {
-            data: AVec::from_iter(SIMD_ALIGN, (0..len).map(|_| torus_element_generator())),
+            data: avec_from_iter!((0..len).map(|_| torus_element_generator())),
         }
     }
 
@@ -213,12 +213,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(
-            SIMD_ALIGN,
+        let sk3_expected = avec_from_iter!(
             sk.data
                 .iter()
                 .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_add(b)),
+                .map(|(a, b)| a.wrapping_add(b))
         );
 
         let sk3 = sk + sk2;
@@ -233,12 +232,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let mut sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk2_expected = AVec::from_iter(
-            SIMD_ALIGN,
+        let sk2_expected = avec_from_iter!(
             sk.data
                 .iter()
                 .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_add(b)),
+                .map(|(a, b)| a.wrapping_add(b))
         );
 
         sk2 += sk;
@@ -253,12 +251,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(
-            SIMD_ALIGN,
+        let sk3_expected = avec_from_iter!(
             sk.data
                 .iter()
                 .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_add(b)),
+                .map(|(a, b)| a.wrapping_add(b))
         );
 
         let sk3 = sk.as_ref() + sk2.as_ref();
@@ -273,12 +270,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(
-            SIMD_ALIGN,
+        let sk3_expected = avec_from_iter!(
             sk.data
                 .iter()
                 .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_add(b)),
+                .map(|(a, b)| a.wrapping_add(b))
         );
 
         let sk3 = sk.wrapping_add(&sk2);
@@ -295,12 +291,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(
-            SIMD_ALIGN,
+        let sk3_expected = avec_from_iter!(
             sk.data
                 .iter()
                 .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_sub(b)),
+                .map(|(a, b)| a.wrapping_sub(b))
         );
 
         let sk3 = sk - sk2;
@@ -315,12 +310,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let mut sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk2_expected = AVec::from_iter(
-            SIMD_ALIGN,
+        let sk2_expected = avec_from_iter!(
             sk2.data
                 .iter()
                 .zip(sk.data.iter())
-                .map(|(a, b)| a.wrapping_sub(b)),
+                .map(|(a, b)| a.wrapping_sub(b))
         );
 
         sk2 -= sk;
@@ -335,12 +329,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(
-            SIMD_ALIGN,
+        let sk3_expected = avec_from_iter!(
             sk.data
                 .iter()
                 .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_sub(b)),
+                .map(|(a, b)| a.wrapping_sub(b))
         );
 
         let sk3 = sk.as_ref() - sk2.as_ref();
@@ -355,12 +348,11 @@ mod tests {
         let sk = keygen::generate_uniform_glwe_sk(&params);
         let sk2 = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk3_expected = AVec::from_iter(
-            SIMD_ALIGN,
+        let sk3_expected = avec_from_iter!(
             sk.data
                 .iter()
                 .zip(sk2.data.iter())
-                .map(|(a, b)| a.wrapping_sub(b)),
+                .map(|(a, b)| a.wrapping_sub(b))
         );
 
         let sk3 = sk.wrapping_sub(&sk2);
@@ -376,7 +368,7 @@ mod tests {
 
         let sk = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk2_expected = AVec::from_iter(SIMD_ALIGN, sk.data.iter().map(|a| a.wrapping_neg()));
+        let sk2_expected = avec_from_iter!(sk.data.iter().map(|a| a.wrapping_neg()));
         let sk2 = -sk;
 
         assert_eq!(sk2_expected, sk2.data)
@@ -388,7 +380,7 @@ mod tests {
 
         let sk = keygen::generate_uniform_glwe_sk(&params);
 
-        let sk2_expected = AVec::from_iter(SIMD_ALIGN, sk.data.iter().map(|a| a.wrapping_neg()));
+        let sk2_expected = avec_from_iter!(sk.data.iter().map(|a| a.wrapping_neg()));
         let sk2 = -sk.as_ref();
 
         assert_eq!(sk2_expected, sk2.data)
@@ -400,7 +392,7 @@ mod tests {
 
         let sk = keygen::generate_binary_glwe_sk(&params);
 
-        let sk2_expected = AVec::from_iter(SIMD_ALIGN, sk.data.iter().map(|a| a.wrapping_neg()));
+        let sk2_expected = avec_from_iter!(sk.data.iter().map(|a| a.wrapping_neg()));
         let sk2 = sk.wrapping_neg();
 
         assert_eq!(sk2_expected, sk2.data)

--- a/sunscreen_tfhe/src/entities/glwe_secret_key.rs
+++ b/sunscreen_tfhe/src/entities/glwe_secret_key.rs
@@ -1,4 +1,4 @@
-use aligned_vec::AVec;
+
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -9,7 +9,6 @@ use crate::{
         decrypt_glwe_ciphertext, encrypt_ggsw_ciphertext, encrypt_glwe_ciphertext_secret,
     },
     rand::{binary, uniform_torus},
-    scratch::SIMD_ALIGN,
     GlweDef, GlweDimension, PlaintextBits, RadixDecomposition, Torus, TorusOps,
 };
 
@@ -182,7 +181,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::{high_level::*, GLWE_1_1024_80};
 
     use num::traits::{WrappingAdd, WrappingNeg, WrappingSub};

--- a/sunscreen_tfhe/src/entities/lwe_ciphertext.rs
+++ b/sunscreen_tfhe/src/entities/lwe_ciphertext.rs
@@ -40,7 +40,7 @@ impl<S: TorusOps> LweCiphertext<S> {
 
     /// Create a new LWE ciphertext with all coefficients set to zero.
     pub fn zero(params: &LweDef) -> Self {
-        let data = vec![Torus::zero(); LweCiphertextRef::<S>::size(params.dim)];
+        let data = avec![Torus::zero(); LweCiphertextRef::<S>::size(params.dim)];
 
         Self { data }
     }

--- a/sunscreen_tfhe/src/entities/lwe_ciphertext_list.rs
+++ b/sunscreen_tfhe/src/entities/lwe_ciphertext_list.rs
@@ -31,7 +31,7 @@ impl<S: TorusOps> LweCiphertextList<S> {
     /// [`circuit_bootstrap`](crate::ops::bootstrapping::circuit_bootstrap).
     pub fn new(lwe: &LweDef, count: usize) -> Self {
         Self {
-            data: vec![Torus::zero(); LweCiphertextListRef::<S>::size((lwe.dim, count))],
+            data: avec![Torus::zero(); LweCiphertextListRef::<S>::size((lwe.dim, count))],
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/lwe_keyswitch_key.rs
+++ b/sunscreen_tfhe/src/entities/lwe_keyswitch_key.rs
@@ -48,7 +48,7 @@ where
             LweKeyswitchKeyRef::<S>::size((original_params.dim, new_params.dim, radix.count));
 
         Self {
-            data: vec![Torus::zero(); elems],
+            data: avec![Torus::zero(); elems],
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/lwe_public_key.rs
+++ b/sunscreen_tfhe/src/entities/lwe_public_key.rs
@@ -55,7 +55,7 @@ where
         sk.assert_valid(params);
 
         let mut pk = LwePublicKey {
-            data: vec![Torus::zero(); LwePublicKeyRef::<S>::size(params.dim)],
+            data: avec![Torus::zero(); LwePublicKeyRef::<S>::size(params.dim)],
         };
         let enc_zeros = pk.enc_zeros_mut(params);
 

--- a/sunscreen_tfhe/src/entities/lwe_secret_key.rs
+++ b/sunscreen_tfhe/src/entities/lwe_secret_key.rs
@@ -45,7 +45,7 @@ where
         let len = LweSecretKeyRef::<S>::size(params.dim);
 
         LweSecretKey {
-            data: AVec::from_iter(SIMD_ALIGN, (0..len).map(|_| torus_element_generator())),
+            data: avec_from_iter!((0..len).map(|_| torus_element_generator())),
         }
     }
 

--- a/sunscreen_tfhe/src/entities/lwe_secret_key.rs
+++ b/sunscreen_tfhe/src/entities/lwe_secret_key.rs
@@ -3,7 +3,12 @@ use num::Zero;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::{NoWrapper, OverlaySize}, macros::{impl_binary_op, impl_unary_op}, ops::encryption::encode_and_encrypt_lwe_ciphertext, rand::{binary, uniform_torus}, scratch::SIMD_ALIGN, LweDef, LweDimension, PlaintextBits, Torus, TorusOps
+    dst::{NoWrapper, OverlaySize},
+    macros::{impl_binary_op, impl_unary_op},
+    ops::encryption::encode_and_encrypt_lwe_ciphertext,
+    rand::{binary, uniform_torus},
+    scratch::SIMD_ALIGN,
+    LweDef, LweDimension, PlaintextBits, Torus, TorusOps,
 };
 
 use super::{LweCiphertext, LweCiphertextRef};
@@ -40,9 +45,7 @@ where
         let len = LweSecretKeyRef::<S>::size(params.dim);
 
         LweSecretKey {
-            data: AVec::from_iter(SIMD_ALIGN, (0..len)
-                .map(|_| torus_element_generator())
-            ),
+            data: AVec::from_iter(SIMD_ALIGN, (0..len).map(|_| torus_element_generator())),
         }
     }
 

--- a/sunscreen_tfhe/src/entities/lwe_secret_key.rs
+++ b/sunscreen_tfhe/src/entities/lwe_secret_key.rs
@@ -1,4 +1,3 @@
-
 use num::Zero;
 use serde::{Deserialize, Serialize};
 

--- a/sunscreen_tfhe/src/entities/lwe_secret_key.rs
+++ b/sunscreen_tfhe/src/entities/lwe_secret_key.rs
@@ -1,4 +1,4 @@
-use aligned_vec::AVec;
+
 use num::Zero;
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +7,6 @@ use crate::{
     macros::{impl_binary_op, impl_unary_op},
     ops::encryption::encode_and_encrypt_lwe_ciphertext,
     rand::{binary, uniform_torus},
-    scratch::SIMD_ALIGN,
     LweDef, LweDimension, PlaintextBits, Torus, TorusOps,
 };
 

--- a/sunscreen_tfhe/src/entities/lwe_secret_key.rs
+++ b/sunscreen_tfhe/src/entities/lwe_secret_key.rs
@@ -1,12 +1,9 @@
+use aligned_vec::AVec;
 use num::Zero;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    dst::{NoWrapper, OverlaySize},
-    macros::{impl_binary_op, impl_unary_op},
-    ops::encryption::encode_and_encrypt_lwe_ciphertext,
-    rand::{binary, uniform_torus},
-    LweDef, LweDimension, PlaintextBits, Torus, TorusOps,
+    dst::{NoWrapper, OverlaySize}, macros::{impl_binary_op, impl_unary_op}, ops::encryption::encode_and_encrypt_lwe_ciphertext, rand::{binary, uniform_torus}, scratch::SIMD_ALIGN, LweDef, LweDimension, PlaintextBits, Torus, TorusOps
 };
 
 use super::{LweCiphertext, LweCiphertextRef};
@@ -43,9 +40,9 @@ where
         let len = LweSecretKeyRef::<S>::size(params.dim);
 
         LweSecretKey {
-            data: (0..len)
+            data: AVec::from_iter(SIMD_ALIGN, (0..len)
                 .map(|_| torus_element_generator())
-                .collect::<Vec<_>>(),
+            ),
         }
     }
 

--- a/sunscreen_tfhe/src/entities/polynomial.rs
+++ b/sunscreen_tfhe/src/entities/polynomial.rs
@@ -285,12 +285,13 @@ where
     fn add(self, rhs: &PolynomialRef<S>) -> Self::Output {
         assert_eq!(self.data.as_ref().len(), rhs.data.as_ref().len());
 
-        let coeffs = AVec::from_iter(SIMD_ALIGN, self
-            .coeffs()
-            .as_ref()
-            .iter()
-            .zip(rhs.coeffs().as_ref().iter())
-            .map(|(a, b)| *a + *b)
+        let coeffs = AVec::from_iter(
+            SIMD_ALIGN,
+            self.coeffs()
+                .as_ref()
+                .iter()
+                .zip(rhs.coeffs().as_ref().iter())
+                .map(|(a, b)| *a + *b),
         );
 
         Polynomial { data: coeffs }
@@ -326,12 +327,13 @@ where
     fn sub(self, rhs: &PolynomialRef<S>) -> Self::Output {
         assert_eq!(self.data.as_ref().len(), rhs.data.as_ref().len());
 
-        let coeffs = AVec::from_iter(SIMD_ALIGN, self
-            .coeffs()
-            .as_ref()
-            .iter()
-            .zip(rhs.coeffs().as_ref().iter())
-            .map(|(a, b)| *a - *b)
+        let coeffs = AVec::from_iter(
+            SIMD_ALIGN,
+            self.coeffs()
+                .as_ref()
+                .iter()
+                .zip(rhs.coeffs().as_ref().iter())
+                .map(|(a, b)| *a - *b),
         );
 
         Polynomial { data: coeffs }

--- a/sunscreen_tfhe/src/entities/polynomial.rs
+++ b/sunscreen_tfhe/src/entities/polynomial.rs
@@ -65,7 +65,7 @@ where
 {
     fn from_iter<I: IntoIterator<Item = T>>(iter: I) -> Self {
         Self {
-            data: AVec::from_iter(SIMD_ALIGN, iter),
+            data: avec_from_iter!(iter),
         }
     }
 }
@@ -92,7 +92,7 @@ where
         U: Clone,
     {
         Polynomial {
-            data: AVec::from_iter(SIMD_ALIGN, self.data.iter().map(f)),
+            data: avec_from_iter!(self.data.iter().map(f)),
         }
     }
 
@@ -285,13 +285,12 @@ where
     fn add(self, rhs: &PolynomialRef<S>) -> Self::Output {
         assert_eq!(self.data.as_ref().len(), rhs.data.as_ref().len());
 
-        let coeffs = AVec::from_iter(
-            SIMD_ALIGN,
+        let coeffs = avec_from_iter!(
             self.coeffs()
                 .as_ref()
                 .iter()
                 .zip(rhs.coeffs().as_ref().iter())
-                .map(|(a, b)| *a + *b),
+                .map(|(a, b)| *a + *b)
         );
 
         Polynomial { data: coeffs }
@@ -327,13 +326,12 @@ where
     fn sub(self, rhs: &PolynomialRef<S>) -> Self::Output {
         assert_eq!(self.data.as_ref().len(), rhs.data.as_ref().len());
 
-        let coeffs = AVec::from_iter(
-            SIMD_ALIGN,
+        let coeffs = avec_from_iter!(
             self.coeffs()
                 .as_ref()
                 .iter()
                 .zip(rhs.coeffs().as_ref().iter())
-                .map(|(a, b)| *a - *b),
+                .map(|(a, b)| *a - *b)
         );
 
         Polynomial { data: coeffs }

--- a/sunscreen_tfhe/src/entities/polynomial.rs
+++ b/sunscreen_tfhe/src/entities/polynomial.rs
@@ -44,7 +44,7 @@ where
     /// Create a new polynomial from a slice of coefficients.
     pub fn new(data: &[T]) -> Polynomial<T> {
         Polynomial {
-            data: AVec::from_slice(SIMD_ALIGN, data),
+            data: avec_from_slice!(data),
         }
     }
 

--- a/sunscreen_tfhe/src/entities/polynomial.rs
+++ b/sunscreen_tfhe/src/entities/polynomial.rs
@@ -3,14 +3,13 @@ use std::{
     ops::{Add, AddAssign, Mul, Sub, SubAssign},
 };
 
-use aligned_vec::AVec;
 use num::{Complex, Zero};
 
 use crate::{
     dst::{FromMutSlice, FromSlice, NoWrapper, OverlaySize},
     fft::negacyclic::get_fft,
     polynomial::{polynomial_add_assign, polynomial_external_mad, polynomial_sub_assign},
-    scratch::{allocate_scratch, SIMD_ALIGN},
+    scratch::allocate_scratch,
     FrequencyTransform, PolynomialDegree, ReinterpretAsSigned, ToF64, Torus, TorusOps,
 };
 
@@ -285,13 +284,12 @@ where
     fn add(self, rhs: &PolynomialRef<S>) -> Self::Output {
         assert_eq!(self.data.as_ref().len(), rhs.data.as_ref().len());
 
-        let coeffs = avec_from_iter!(
-            self.coeffs()
-                .as_ref()
-                .iter()
-                .zip(rhs.coeffs().as_ref().iter())
-                .map(|(a, b)| *a + *b)
-        );
+        let coeffs = avec_from_iter!(self
+            .coeffs()
+            .as_ref()
+            .iter()
+            .zip(rhs.coeffs().as_ref().iter())
+            .map(|(a, b)| *a + *b));
 
         Polynomial { data: coeffs }
     }
@@ -326,13 +324,12 @@ where
     fn sub(self, rhs: &PolynomialRef<S>) -> Self::Output {
         assert_eq!(self.data.as_ref().len(), rhs.data.as_ref().len());
 
-        let coeffs = avec_from_iter!(
-            self.coeffs()
-                .as_ref()
-                .iter()
-                .zip(rhs.coeffs().as_ref().iter())
-                .map(|(a, b)| *a - *b)
-        );
+        let coeffs = avec_from_iter!(self
+            .coeffs()
+            .as_ref()
+            .iter()
+            .zip(rhs.coeffs().as_ref().iter())
+            .map(|(a, b)| *a - *b));
 
         Polynomial { data: coeffs }
     }

--- a/sunscreen_tfhe/src/entities/polynomial_fft.rs
+++ b/sunscreen_tfhe/src/entities/polynomial_fft.rs
@@ -1,10 +1,9 @@
-use aligned_vec::AVec;
 use num::{traits::MulAdd, Complex};
 
 use crate::{
     dst::{NoWrapper, OverlaySize},
     fft::negacyclic::get_fft,
-    scratch::{allocate_scratch, SIMD_ALIGN},
+    scratch::allocate_scratch,
     FrequencyTransform, FromF64, NumBits, PolynomialDegree,
 };
 

--- a/sunscreen_tfhe/src/entities/polynomial_fft.rs
+++ b/sunscreen_tfhe/src/entities/polynomial_fft.rs
@@ -1,9 +1,10 @@
+use aligned_vec::AVec;
 use num::{traits::MulAdd, Complex};
 
 use crate::{
     dst::{NoWrapper, OverlaySize},
     fft::negacyclic::get_fft,
-    scratch::allocate_scratch,
+    scratch::{allocate_scratch, SIMD_ALIGN},
     FrequencyTransform, FromF64, NumBits, PolynomialDegree,
 };
 
@@ -46,7 +47,7 @@ where
     /// Create a new polynomial with the given length in the fourier domain.
     pub fn new(data: &[T]) -> Self {
         Self {
-            data: data.to_owned(),
+            data: AVec::from_slice(SIMD_ALIGN, data),
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/polynomial_fft.rs
+++ b/sunscreen_tfhe/src/entities/polynomial_fft.rs
@@ -47,7 +47,7 @@ where
     /// Create a new polynomial with the given length in the fourier domain.
     pub fn new(data: &[T]) -> Self {
         Self {
-            data: AVec::from_slice(SIMD_ALIGN, data),
+            data: avec_from_slice!(data),
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/polynomial_list.rs
+++ b/sunscreen_tfhe/src/entities/polynomial_list.rs
@@ -31,7 +31,7 @@ where
     /// Create a new polynomial list, where each polynomial has the same degree.
     pub fn new(degree: PolynomialDegree, count: usize) -> Self {
         Self {
-            data: vec![S::zero(); degree.0 * count],
+            data: avec![S::zero(); degree.0 * count],
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/private_functional_keyswitch_key.rs
+++ b/sunscreen_tfhe/src/entities/private_functional_keyswitch_key.rs
@@ -66,7 +66,7 @@ impl<S: TorusOps> PrivateFunctionalKeyswitchKey<S> {
         lwe_count: &PrivateFunctionalKeyswitchLweCount,
     ) -> Self {
         Self {
-            data: vec![
+            data: avec![
                 Torus::zero();
                 PrivateFunctionalKeyswitchKeyRef::<S>::size((
                     from_lwe.dim,

--- a/sunscreen_tfhe/src/entities/public_functional_keyswitch_key.rs
+++ b/sunscreen_tfhe/src/entities/public_functional_keyswitch_key.rs
@@ -36,7 +36,7 @@ impl<S: TorusOps> PublicFunctionalKeyswitchKey<S> {
             PublicFunctionalKeyswitchKeyRef::<S>::size((from_lwe.dim, to_glwe.dim, radix.count));
 
         Self {
-            data: vec![Torus::zero(); len],
+            data: avec![Torus::zero(); len],
         }
     }
 }

--- a/sunscreen_tfhe/src/entities/univariate_lookup_table.rs
+++ b/sunscreen_tfhe/src/entities/univariate_lookup_table.rs
@@ -41,7 +41,7 @@ impl<S: TorusOps> UnivariateLookupTable<S> {
         F: Fn(u64) -> u64,
     {
         let mut lut = UnivariateLookupTable {
-            data: vec![Torus::zero(); UnivariateLookupTableRef::<S>::size(glwe.dim)],
+            data: avec![Torus::zero(); UnivariateLookupTableRef::<S>::size(glwe.dim)],
         };
 
         lut.fill_trivial_from_fns(&[map], glwe, plaintext_bits);
@@ -66,7 +66,7 @@ impl<S: TorusOps> UnivariateLookupTable<S> {
         assert!(maps.len() > 1);
 
         let mut lut = UnivariateLookupTable {
-            data: vec![Torus::zero(); UnivariateLookupTableRef::<S>::size(glwe.dim)],
+            data: avec![Torus::zero(); UnivariateLookupTableRef::<S>::size(glwe.dim)],
         };
 
         lut.fill_trivial_from_fns(maps, glwe, plaintext_bits);

--- a/sunscreen_tfhe/src/macros.rs
+++ b/sunscreen_tfhe/src/macros.rs
@@ -84,7 +84,7 @@ macro_rules! impl_unary_op {
                     // We call the wrapping trait instead of using the dot
                     // syntax because the dot syntax can dereference the value
                     // and can cause problems with Deref.
-                    let data = aligned_vec::AVec::from_iter(crate::scratch::SIMD_ALIGN, self.data.iter().map(|a| num::traits::[<Wrapping $op>]::[<wrapping_ $op:lower>](a)));
+                    let data = avec_from_iter!(self.data.iter().map(|a| num::traits::[<Wrapping $op>]::[<wrapping_ $op:lower>](a)));
 
                     $type { data }
                 }

--- a/sunscreen_tfhe/src/macros.rs
+++ b/sunscreen_tfhe/src/macros.rs
@@ -84,7 +84,7 @@ macro_rules! impl_unary_op {
                     // We call the wrapping trait instead of using the dot
                     // syntax because the dot syntax can dereference the value
                     // and can cause problems with Deref.
-                    let data = self.data.iter().map(|a| num::traits::[<Wrapping $op>]::[<wrapping_ $op:lower>](a)).collect();
+                    let data = aligned_vec::AVec::from_iter(crate::scratch::SIMD_ALIGN, self.data.iter().map(|a| num::traits::[<Wrapping $op>]::[<wrapping_ $op:lower>](a)));
 
                     $type { data }
                 }

--- a/sunscreen_tfhe/src/math/torus.rs
+++ b/sunscreen_tfhe/src/math/torus.rs
@@ -212,7 +212,7 @@ impl TorusOps for u32 {}
 
 /// A wrapper around a type that supports Torus operations.
 #[repr(transparent)]
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, PartialOrd, Eq, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Torus<S: TorusOps = u64>(S);
 

--- a/sunscreen_tfhe/src/scratch.rs
+++ b/sunscreen_tfhe/src/scratch.rs
@@ -110,6 +110,13 @@ struct Scratch {
     stack: *mut LinkedList<*mut Allocation>,
 }
 
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let drop_box = unsafe { Box::from_raw(self.stack) };
+        std::mem::drop(drop_box);
+    }
+}
+
 impl Scratch {
     /// We require this to be private. [`allocate_scratch`] should be
     /// the only way to use scratch memory, which will allocate memory

--- a/sunscreen_tfhe/src/scratch.rs
+++ b/sunscreen_tfhe/src/scratch.rs
@@ -368,7 +368,7 @@ mod tests {
 
         #[cfg(target_arch = "x86_64")]
         {
-            assert_eq!(SIMD_ALIGN, 64);    
+            assert_eq!(SIMD_ALIGN, 64);
         }
     }
 }

--- a/sunscreen_tfhe/src/scratch.rs
+++ b/sunscreen_tfhe/src/scratch.rs
@@ -222,7 +222,7 @@ impl<'a, T> Drop for ScratchBuffer<'a, T> {
 
 #[cfg(test)]
 mod tests {
-    use std::{arch::is_aarch64_feature_detected, mem::align_of};
+    use std::mem::align_of;
 
     use super::*;
 

--- a/sunscreen_tfhe/src/scratch.rs
+++ b/sunscreen_tfhe/src/scratch.rs
@@ -5,7 +5,8 @@ use std::{
     cell::RefCell,
     collections::LinkedList,
     marker::PhantomData,
-    mem::{align_of, size_of}, rc::Rc,
+    mem::{align_of, size_of},
+    rc::Rc,
 };
 
 use crate::{Torus, TorusOps};
@@ -115,7 +116,9 @@ impl Scratch {
     /// the only way to use scratch memory, which will allocate memory
     /// using a thread_local allocator.
     fn new() -> Self {
-        Self { stack: Rc::new(RefCell::new(LinkedList::new())) }
+        Self {
+            stack: Rc::new(RefCell::new(LinkedList::new())),
+        }
     }
 
     /// Allocate a buffer matching the given specification.

--- a/sunscreen_tfhe/src/scratch.rs
+++ b/sunscreen_tfhe/src/scratch.rs
@@ -115,7 +115,7 @@ impl Scratch {
     /// the only way to use scratch memory, which will allocate memory
     /// using a thread_local allocator.
     fn new() -> Self {
-        let list = Box::new(LinkedList::new());
+        let list = Box::<LinkedList<*mut Allocation>>::default();
         let list = Box::into_raw(list);
 
         Self { stack: list }
@@ -164,7 +164,7 @@ impl Scratch {
         };
 
         ScratchBuffer {
-            allocation: allocation,
+            allocation,
             pool: self.stack,
             requested_len: count,
             _phantom: PhantomData,
@@ -356,11 +356,7 @@ mod tests {
     fn simd_alignment() {
         #[cfg(target_arch = "aarch64")]
         {
-            if is_aarch64_feature_detected!("neon") {
-                assert_eq!(SIMD_ALIGN, 16);
-            } else {
-                assert_eq!(SIMD_ALIGN, 16);
-            }
+            assert_eq!(SIMD_ALIGN, 16);
         }
 
         #[cfg(target_arch = "x86_64")]

--- a/sunscreen_tfhe/src/scratch.rs
+++ b/sunscreen_tfhe/src/scratch.rs
@@ -28,13 +28,13 @@ macro_rules! allocate_scratch_ref {
 pub(crate) use allocate_scratch_ref;
 
 #[cfg(target_feature = "neon")]
-const SIMD_ALIGN: usize = align_of::<std::arch::aarch64::float64x2_t>();
+pub const SIMD_ALIGN: usize = align_of::<std::arch::aarch64::float64x2_t>();
 
 #[cfg(target_feature = "avx2")]
-const SIMD_ALIGN: usize = align_of::<std::arch::x86_64::__m512d>();
+pub const SIMD_ALIGN: usize = align_of::<std::arch::x86_64::__m512d>();
 
 #[cfg(not(any(target_feature = "neon", target_feaure = "avx2")))]
-const SIMD_ALIGN: usize = align_of::<u128>();
+pub const SIMD_ALIGN: usize = align_of::<u128>();
 
 /// Indicates this is a "Plain Old Data" type. For `T` qualify as such,
 /// all bit patterns must be considered a properly initialized instance of

--- a/sunscreen_tfhe/src/scratch.rs
+++ b/sunscreen_tfhe/src/scratch.rs
@@ -30,10 +30,10 @@ pub(crate) use allocate_scratch_ref;
 #[cfg(target_feature = "neon")]
 pub const SIMD_ALIGN: usize = align_of::<std::arch::aarch64::float64x2_t>();
 
-#[cfg(target_feature = "avx2")]
+#[cfg(target_arch = "x86_64")]
 pub const SIMD_ALIGN: usize = align_of::<std::arch::x86_64::__m512d>();
 
-#[cfg(not(any(target_feature = "neon", target_feaure = "avx2")))]
+#[cfg(not(any(target_feature = "neon", target_arch = "x86_64")))]
 pub const SIMD_ALIGN: usize = align_of::<u128>();
 
 /// Indicates this is a "Plain Old Data" type. For `T` qualify as such,
@@ -368,9 +368,7 @@ mod tests {
 
         #[cfg(target_arch = "x86_64")]
         {
-            if is_x86_feature_detected!("avx2") {
-                assert_eq!(SIMD_ALIGN, 64);
-            }
+            assert_eq!(SIMD_ALIGN, 64);    
         }
     }
 }


### PR DESCRIPTION
Simplify scratch allocation, used `AVec` to meet runtime alignment requirements