### PR TITLE
Typed FHE arguments

### DIFF
--- a/examples/amm/src/main.rs
+++ b/examples/amm/src/main.rs
@@ -1,7 +1,7 @@
 use sunscreen::{
     fhe_program,
     types::{bfv::Rational, Cipher},
-    Ciphertext, CompiledFheProgram, Compiler, Error, FheRuntime, Params, PrivateKey, PublicKey,
+    CompiledFheProgram, Compiler, Error, FheRuntime, Params, PrivateKey, PublicKey,
 };
 
 #[fhe_program(scheme = "bfv")]
@@ -37,14 +37,10 @@ impl Miner {
 
     pub fn run_contract(
         &self,
-        nu_tokens_to_trade: Ciphertext,
+        nu_tokens_to_trade: Cipher<Rational>,
         public_key: &PublicKey,
-    ) -> Result<Ciphertext, Error> {
-        let results =
-            self.runtime
-                .run(&self.compiled_swap_nu, vec![nu_tokens_to_trade], public_key)?;
-
-        Ok(results[0].clone())
+    ) -> Result<Cipher<Rational>, Error> {
+        swap_nu.run(&self.runtime, public_key, nu_tokens_to_trade)
     }
 }
 
@@ -73,13 +69,13 @@ impl Alice {
         })
     }
 
-    pub fn create_transaction(&self, amount: f64) -> Result<Ciphertext, Error> {
+    pub fn create_transaction(&self, amount: f64) -> Result<Cipher<Rational>, Error> {
         Ok(self
             .runtime
             .encrypt(Rational::try_from(amount)?, &self.public_key)?)
     }
 
-    pub fn check_received_eth(&self, received_eth: Ciphertext) -> Result<(), Error> {
+    pub fn check_received_eth(&self, received_eth: Cipher<Rational>) -> Result<(), Error> {
         let received_eth: Rational = self.runtime.decrypt(&received_eth, &self.private_key)?;
 
         let received_eth: f64 = received_eth.into();

--- a/examples/chi_sq/src/main.rs
+++ b/examples/chi_sq/src/main.rs
@@ -169,7 +169,7 @@ fn run_fhe<F, T, U>(
 ) -> Result<(), Error>
 where
     F: FheProgramFn + Clone + 'static + AsRef<str>,
-    U: From<T> + FheType + TypeName + std::fmt::Display,
+    U: From<T> + FheType + TypeName + std::fmt::Display + 'static,
 {
     let start = Instant::now();
 

--- a/sunscreen/src/lib.rs
+++ b/sunscreen/src/lib.rs
@@ -53,7 +53,7 @@ pub mod zkp;
 use fhe::{FheOperation, Literal};
 use petgraph::stable_graph::StableGraph;
 use serde::{Deserialize, Serialize};
-use sunscreen_runtime::{marker, Fhe, FheZkp, Zkp};
+use sunscreen_runtime::{Fhe, FheZkp, Zkp};
 
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -66,10 +66,11 @@ pub use seal_fhe::Plaintext as SealPlaintext;
 pub use sunscreen_compiler_macros::*;
 pub use sunscreen_fhe_program::{SchemeType, SecurityLevel};
 pub use sunscreen_runtime::{
-    CallSignature, Ciphertext, CompiledFheProgram, CompiledZkpProgram, Error as RuntimeError,
-    FheProgramInput, FheProgramInputTrait, FheProgramMetadata, FheRuntime, FheZkpRuntime,
-    InnerCiphertext, InnerPlaintext, Params, Plaintext, PrivateKey, ProofBuilder, PublicKey,
-    RequiredKeys, Runtime, VerificationBuilder, WithContext, ZkpProgramInput, ZkpRuntime,
+    marker, CallSignature, Ciphertext, CompiledFheProgram, CompiledZkpProgram,
+    Error as RuntimeError, FheProgramInput, FheProgramMetadata, FheProgramPlaintextInput,
+    FheRuntime, FheZkpRuntime, GenericRuntime, InnerCiphertext, InnerPlaintext, Params, Plaintext,
+    PrivateKey, ProofBuilder, PublicKey, RequiredKeys, Runtime, VerificationBuilder, WithContext,
+    ZkpProgramInput, ZkpRuntime,
 };
 #[cfg(feature = "bulletproofs")]
 pub use sunscreen_zkp_backend::bulletproofs;

--- a/sunscreen/src/types/bfv/batched.rs
+++ b/sunscreen/src/types/bfv/batched.rs
@@ -6,14 +6,14 @@ use crate::{
         BfvType, FheType, LaneCount, NumCiphertexts, SwapRows, TryFromPlaintext, TryIntoPlaintext,
         Type, TypeName, TypeNameInstance, Version,
     },
-    FheProgramInputTrait, InnerPlaintext, Params, Plaintext, WithContext,
+    FheProgramPlaintextInput, InnerPlaintext, Params, Plaintext, WithContext,
 };
 use seal_fhe::{
     BFVEncoder, BfvEncryptionParametersBuilder, Context as SealContext, Modulus,
     Result as SealResult,
 };
 use std::ops::*;
-use sunscreen_runtime::{Error as RuntimeError, Result as RuntimeResult};
+use sunscreen_runtime::{Error as RuntimeError, FheProgramInput, Result as RuntimeResult};
 
 /**
  * A Batched vector of signed integers. The vector has 2 rows of `LANES`
@@ -91,7 +91,12 @@ impl<const LANES: usize> TypeNameInstance for Batched<LANES> {
     }
 }
 
-impl<const LANES: usize> FheProgramInputTrait for Batched<LANES> {}
+impl<const LANES: usize> FheProgramPlaintextInput for Batched<LANES> {}
+impl<const LANES: usize> From<Batched<LANES>> for FheProgramInput {
+    fn from(value: Batched<LANES>) -> Self {
+        Self::Plaintext(Box::new(value))
+    }
+}
 impl<const LANES: usize> FheType for Batched<LANES> {}
 impl<const LANES: usize> BfvType for Batched<LANES> {}
 

--- a/sunscreen/src/types/bfv/fractional.rs
+++ b/sunscreen/src/types/bfv/fractional.rs
@@ -14,12 +14,12 @@ use crate::{
 };
 use crate::{
     types::{intern::FheProgramNode, BfvType, FheType, Type, Version},
-    FheProgramInputTrait, Params, WithContext,
+    FheProgramPlaintextInput, Params, WithContext,
 };
 
 use sunscreen_runtime::{
-    InnerPlaintext, NumCiphertexts, Plaintext, TryFromPlaintext, TryIntoPlaintext, TypeName,
-    TypeNameInstance,
+    FheProgramInput, InnerPlaintext, NumCiphertexts, Plaintext, TryFromPlaintext, TryIntoPlaintext,
+    TypeName, TypeNameInstance,
 };
 
 use std::ops::*;
@@ -174,7 +174,12 @@ impl<const INT_BITS: usize> NumCiphertexts for Fractional<INT_BITS> {
     const NUM_CIPHERTEXTS: usize = 1;
 }
 
-impl<const INT_BITS: usize> FheProgramInputTrait for Fractional<INT_BITS> {}
+impl<const INT_BITS: usize> FheProgramPlaintextInput for Fractional<INT_BITS> {}
+impl<const INT_BITS: usize> From<Fractional<INT_BITS>> for FheProgramInput {
+    fn from(value: Fractional<INT_BITS>) -> Self {
+        Self::Plaintext(Box::new(value))
+    }
+}
 
 impl<const INT_BITS: usize> Default for Fractional<INT_BITS> {
     fn default() -> Self {

--- a/sunscreen/src/types/bfv/rational.rs
+++ b/sunscreen/src/types/bfv/rational.rs
@@ -4,10 +4,10 @@ use crate::types::{
     bfv::Signed, intern::FheProgramNode, ops::*, BfvType, Cipher, FheType, NumCiphertexts,
     TryFromPlaintext, TryIntoPlaintext, TypeName,
 };
-use crate::{FheProgramInputTrait, InnerPlaintext, Params, Plaintext, TypeName};
+use crate::{FheProgramPlaintextInput, InnerPlaintext, Params, Plaintext, TypeName};
 use std::cmp::Eq;
 use std::ops::*;
-use sunscreen_runtime::Error;
+use sunscreen_runtime::{impl_into_fhe_program_plaintext_input, Error};
 
 use num::Rational64;
 
@@ -96,7 +96,8 @@ impl TryIntoPlaintext for Rational {
     }
 }
 
-impl FheProgramInputTrait for Rational {}
+impl FheProgramPlaintextInput for Rational {}
+impl_into_fhe_program_plaintext_input!(Rational);
 impl FheType for Rational {}
 impl BfvType for Rational {}
 

--- a/sunscreen/src/types/bfv/signed.rs
+++ b/sunscreen/src/types/bfv/signed.rs
@@ -15,11 +15,12 @@ use crate::{
 };
 use crate::{
     types::{intern::FheProgramNode, BfvType, FheType, TypeNameInstance},
-    FheProgramInputTrait, Params, TypeName as DeriveTypeName, WithContext,
+    FheProgramPlaintextInput, Params, TypeName as DeriveTypeName, WithContext,
 };
 
 use sunscreen_runtime::{
-    InnerPlaintext, NumCiphertexts, Plaintext, TryFromPlaintext, TryIntoPlaintext,
+    impl_into_fhe_program_plaintext_input, InnerPlaintext, NumCiphertexts, Plaintext,
+    TryFromPlaintext, TryIntoPlaintext,
 };
 
 use std::ops::*;
@@ -52,7 +53,8 @@ mod sharing {
     }
 }
 
-impl FheProgramInputTrait for Signed {}
+impl FheProgramPlaintextInput for Signed {}
+impl_into_fhe_program_plaintext_input!(Signed);
 impl FheType for Signed {}
 impl BfvType for Signed {}
 

--- a/sunscreen/src/types/bfv/unsigned.rs
+++ b/sunscreen/src/types/bfv/unsigned.rs
@@ -5,7 +5,7 @@ use paste::paste;
 use seal_fhe::Plaintext as SealPlaintext;
 
 use sunscreen_runtime::{
-    InnerPlaintext, NumCiphertexts, Plaintext, TryFromPlaintext, TryIntoPlaintext,
+    FheProgramInput, InnerPlaintext, NumCiphertexts, Plaintext, TryFromPlaintext, TryIntoPlaintext,
 };
 
 use crate as sunscreen;
@@ -23,7 +23,7 @@ use crate::{
 };
 use crate::{
     types::{intern::FheProgramNode, BfvType, FheType, TypeNameInstance},
-    FheProgramInputTrait, Params, TypeName as DeriveTypeName, WithContext,
+    FheProgramPlaintextInput, Params, TypeName as DeriveTypeName, WithContext,
 };
 
 #[derive(Debug, Clone, Copy, DeriveTypeName, PartialEq, Eq)]
@@ -38,7 +38,12 @@ impl<const LIMBS: usize> NumCiphertexts for Unsigned<LIMBS> {
     const NUM_CIPHERTEXTS: usize = 1;
 }
 
-impl<const LIMBS: usize> FheProgramInputTrait for Unsigned<LIMBS> {}
+impl<const LIMBS: usize> FheProgramPlaintextInput for Unsigned<LIMBS> {}
+impl<const LIMBS: usize> From<Unsigned<LIMBS>> for FheProgramInput {
+    fn from(value: Unsigned<LIMBS>) -> Self {
+        Self::Plaintext(Box::new(value))
+    }
+}
 impl<const LIMBS: usize> FheType for Unsigned<LIMBS> {}
 impl<const LIMBS: usize> BfvType for Unsigned<LIMBS> {}
 

--- a/sunscreen/src/types/intern/fhe_program_node.rs
+++ b/sunscreen/src/types/intern/fhe_program_node.rs
@@ -12,7 +12,7 @@ use sunscreen_runtime::TypeNameInstance;
 
 use std::ops::{Add, Div, Mul, Neg, Shl, Shr, Sub};
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq)]
 /**
  * A type that wraps an FheType during graph construction. It is an implementation
  * detail and you should not construct these directly.
@@ -54,6 +54,17 @@ pub struct FheProgramNode<T: NumCiphertexts, S = ()> {
 
     /// Marks the type of the value that this graph node corresponds to.
     _phantom: std::marker::PhantomData<T>,
+}
+
+impl<T: sunscreen_runtime::NumCiphertexts, S: Copy> Copy for FheProgramNode<T, S> {}
+impl<T: sunscreen_runtime::NumCiphertexts, S: Clone> Clone for FheProgramNode<T, S> {
+    fn clone(&self) -> Self {
+        Self {
+            ids: self.ids,
+            stage: self.stage.clone(),
+            _phantom: self._phantom,
+        }
+    }
 }
 
 impl<T: NumCiphertexts> FheProgramNode<T> {

--- a/sunscreen/src/types/mod.rs
+++ b/sunscreen/src/types/mod.rs
@@ -75,7 +75,7 @@ mod ops;
 pub mod zkp;
 
 pub use sunscreen_runtime::{
-    BfvType, FheType, NumCiphertexts, TryFromPlaintext, TryIntoPlaintext, Type, TypeName,
+    BfvType, Cipher, FheType, NumCiphertexts, TryFromPlaintext, TryIntoPlaintext, Type, TypeName,
     TypeNameInstance, Version,
 };
 
@@ -102,36 +102,6 @@ pub trait LaneCount {
      * The number of lanes.
      */
     fn lane_count() -> usize;
-}
-
-#[derive(Copy, Clone, Debug)]
-/**
- * Declares a type T as being encrypted in an [`fhe_program`](crate::fhe_program).
- */
-pub struct Cipher<T>
-where
-    T: FheType,
-{
-    _val: T,
-}
-
-impl<T> NumCiphertexts for Cipher<T>
-where
-    T: FheType,
-{
-    const NUM_CIPHERTEXTS: usize = T::NUM_CIPHERTEXTS;
-}
-
-impl<T> TypeName for Cipher<T>
-where
-    T: FheType + TypeName,
-{
-    fn type_name() -> Type {
-        Type {
-            is_encrypted: true,
-            ..T::type_name()
-        }
-    }
 }
 
 /// Creates new FHE variables from literals.

--- a/sunscreen/tests/array.rs
+++ b/sunscreen/tests/array.rs
@@ -91,12 +91,15 @@ fn multidimensional_arrays() {
     let result = runtime
         .run(
             app.get_fhe_program(determinant).unwrap(),
-            vec![a_c],
+            vec![a_c.clone()],
             &public_key,
         )
         .unwrap();
 
-    let c: Signed = runtime.decrypt(&result[0], &private_key).unwrap();
+    let spf = determinant.as_spf(&public_key);
+    let res = spf(a_c).unwrap();
+
+    let c: Signed = runtime.decrypt(&res, &private_key).unwrap();
 
     assert_eq!(c, Signed::from(-3));
     assert_eq!(c, determinant_impl(matrix));

--- a/sunscreen/tests/sdlp.rs
+++ b/sunscreen/tests/sdlp.rs
@@ -94,11 +94,7 @@ mod sdlp_tests {
         fn double(x: sunscreen::types::Cipher<Signed>) -> sunscreen::types::Cipher<Signed> {
             x + x
         }
-        let double_compiled = double.compile().unwrap();
-        let computed_ct = rt
-            .run(&double_compiled, vec![initial_ct], &public_key)
-            .unwrap()
-            .remove(0);
+        let computed_ct = double.run(&rt, &public_key, initial_ct).unwrap();
 
         let mut logproof_builder = SdlpBuilder::new(&rt);
         let (_, msg) = logproof_builder

--- a/sunscreen_compiler_macros/src/fhe_program_transforms.rs
+++ b/sunscreen_compiler_macros/src/fhe_program_transforms.rs
@@ -1,6 +1,8 @@
 use proc_macro2::{Span, TokenStream as TokenStream2};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
-use syn::{parse_quote, parse_quote_spanned, spanned::Spanned, Ident, Index, ReturnType, Type};
+use syn::{
+    parse_quote, parse_quote_spanned, spanned::Spanned, Ident, Index, ReturnType, Type, TypePath,
+};
 
 #[derive(Debug)]
 pub enum MapFheTypeError {
@@ -17,6 +19,34 @@ pub fn map_fhe_type(arg_type: &Type) -> Result<Type, MapFheTypeError> {
         Type::Path(ty) => parse_quote_spanned! {ty.span() => FheProgramNode<#ty> },
         Type::Array(a) => {
             let inner_type = map_fhe_type(&a.elem)?;
+            let len = &a.len;
+
+            parse_quote_spanned! {a.span() =>
+                [#inner_type; #len]
+            }
+        }
+        _ => {
+            return Err(MapFheTypeError::IllegalType(arg_type.span()));
+        }
+    };
+
+    Ok(transformed_type)
+}
+
+/**
+ * Given an input type T, returns
+ * * sunscreen::Ciphertext when T is a Cipher<_> or [[..[Cipher<_>; N];.. M]; Q]
+ * * T otherwise
+ */
+pub fn map_spf_type(arg_type: &Type) -> Result<Type, MapFheTypeError> {
+    let transformed_type = match arg_type {
+        // Hack
+        ty if is_inner_cipher(ty) => {
+            parse_quote_spanned! {ty.span() => sunscreen::Ciphertext }
+        }
+        Type::Path(ty) => parse_quote_spanned! {ty.span() => #ty },
+        Type::Array(a) => {
+            let inner_type = map_spf_type(&a.elem)?;
             let len = &a.len;
 
             parse_quote_spanned! {a.span() =>
@@ -205,6 +235,31 @@ pub fn emit_signature(args: &[Type], return_types: &[Type]) -> TokenStream2 {
             num_ciphertexts: vec![#(#return_type_sizes)*],
         }
     }
+}
+
+// Hack: we should also change [Cipher<T>] to accept [Ciphertext] rather than Ciphertext.
+fn is_inner_cipher(arr: &Type) -> bool {
+    match arr {
+        Type::Array(a) => is_inner_cipher(&a.elem),
+        Type::Path(ty) => is_path_cipher(ty),
+        _ => false,
+    }
+}
+
+// Hack: we should actually use `Cipher<T>` instead of `Ciphertext` more broadly.
+fn is_path_cipher(ty: &TypePath) -> bool {
+    // Ensure there exists some Cipher<T> in sunscreen::types::Cipher<T>
+    let cipher_seg = match ty.path.segments.last() {
+        Some(seg) => seg,
+        None => return false,
+    };
+    // Ensure there exists some T in Cipher<T>
+    match &cipher_seg.arguments {
+        syn::PathArguments::AngleBracketed(ab) if ab.args.len() == 1 => (),
+        _ => return false,
+    }
+    // Ensure the Cipher in Cipher<T>
+    cipher_seg.ident == "Cipher"
 }
 
 #[cfg(test)]


### PR DESCRIPTION
# before

```rust
// Below, `Cipher` is not a "real" type. You never construct values of it.
#[fhe_program(scheme = "bfv")]
fn add_and_mul(a: Signed, b: Cipher<Signed>) -> (Cipher<Signed>, Cipher<Signed>) {
    (a + b, a * b)
}

let prog = add_and_mul.compile()?;
let runtime = add_and_mul.runtime()?;

let a = Signed::from(5);
// b instead has type `Ciphertext`
let b = runtime.encrypt(Signed::from(10), &public_key)?;

// runtime::run accepts a vector of inputs, so they all need to be casted to the `FheProgramInput` type.
let args: Vec<FheProgramInput> = vec![a.into(), b.into()];
let result = runtime
    .run(prog, args, &public_key)
    .unwrap();

let c: Signed = runtime.decrypt(&result[0], &private_key)?;
let d: Signed = runtime.decrypt(&result[1], &private_key)?;
```

# after
```rust
// Now `Cipher<Signed>` is a real type - it's what you get when you encrypt a `Signed` value.
#[fhe_program(scheme = "bfv")]
fn add_and_mul(a: Signed, b: Cipher<Signed>) -> (Cipher<Signed>, Cipher<Signed>) {
    (a + b, a * b)
}

let runtime = add_and_mul.runtime()?;

let a = Signed::from(5);
// Here b has type `Cipher<Signed>`.
let b = runtime.encrypt(Signed::from(10), &public_key)?;

// Here the user passes in typed arguments and gets typed return values.
let (c_enc, d_enc) = add_and_mul.run(&runtime, &public_key, a, b)?;

let c: Signed = runtime.decrypt(&c_enc, &private_key)?;
let d: Signed = runtime.decrypt(&d_enc, &private_key)?;
```

# outstanding work

### arrays
We have one issue left, which is accepting both arrays of plaintexts and arrays of ciphertexts. The issue is that to support arbitrarily nested arrays, the impl for `Into<FheProgramInput>` has to be generic, but without specialization, or negative type bounds, there's no way to have two blanket impls. Perhaps there is an avenue where FHE programs instead accept e.g. `Cipher<[Signed; 5]>` instead of `[Cipher<Signed>; 5]`, with appropriate `Index`-ing, however this might make the FHE program body awkward, as you no longer have a "first class" array.

### supporting dynamic calls on generic programs
Due to limitations of stable rust, this `run` function needs to exist on the fhe program impl, and not a trait. We _could_ put this on a trait, but it would likely have to go on the `FheProgramExt` trait (so that we don't screw up vectors of compiled FHE programs), and it would require packing all arguments into a tuple. Once the `Tuple` trait is stabilized we could avoid that.