### PR TITLE
Implement scheme switching

### DIFF
--- a/sunscreen_tfhe/src/entities/mod.rs
+++ b/sunscreen_tfhe/src/entities/mod.rs
@@ -69,3 +69,9 @@ pub use polynomial_fft::*;
 
 mod polynomial_list;
 pub use polynomial_list::*;
+
+mod scheme_switch_key;
+pub use scheme_switch_key::*;
+
+mod scheme_switch_key_fft;
+pub use scheme_switch_key_fft::*;

--- a/sunscreen_tfhe/src/entities/polynomial.rs
+++ b/sunscreen_tfhe/src/entities/polynomial.rs
@@ -365,6 +365,20 @@ where
     }
 }
 
+impl<T: PartialEq + Clone> PartialEq for PolynomialRef<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.coeffs() == other.coeffs()
+    }
+}
+
+impl<T: std::fmt::Debug + Clone> std::fmt::Debug for PolynomialRef<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PolynomialRef")
+            .field("coeffs", &self.coeffs())
+            .finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::ops::Deref;

--- a/sunscreen_tfhe/src/entities/scheme_switch_key.rs
+++ b/sunscreen_tfhe/src/entities/scheme_switch_key.rs
@@ -1,0 +1,271 @@
+use num::{Complex, Zero};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    dst::OverlaySize, GlweDef, GlweDimension, RadixCount, RadixDecomposition, Torus, TorusOps,
+};
+
+use super::{
+    GlevCiphertextIterator, GlevCiphertextIteratorMut, GlevCiphertextRef, GlweCiphertextRef,
+    SchemeSwitchKeyFftRef,
+};
+
+/// Calculates the number of entries in an upper/lower triangular square matrix,
+/// including the diagonal.
+pub(crate) fn triangular_number_entries(n: usize) -> usize {
+    (n * (n + 1)) / 2
+}
+
+/// Returns the linear index of the upper triangular matrix at the given row and
+/// column index.
+pub(crate) fn get_linear_index(i: usize, j: usize, n: usize) -> usize {
+    assert!(i < n && j < n, "Indices must be less than matrix dimension");
+
+    // Ensure we're always working with the upper triangle (transpose lower
+    // triangular values)
+    let (row, col) = if i <= j { (i, j) } else { (j, i) };
+
+    // https://stackoverflow.com/a/39796318
+    (n * (n + 1) / 2) - (n - row) * ((n - row) + 1) / 2 + col - row
+}
+
+dst! {
+    /// A scheme switch key
+    SchemeSwitchKey,
+    SchemeSwitchKeyRef,
+    Torus,
+    (Clone, Debug, Serialize, Deserialize),
+    (TorusOps,)
+}
+dst_iter! { SchemeSwitchKeyIterator, SchemeSwitchKeyIteratorMut, ParallelSchemeSwitchKeyIterator, ParallelSchemeSwitchKeyIteratorMut, Torus, SchemeSwitchKeyRef, (TorusOps,)}
+
+impl<S> OverlaySize for SchemeSwitchKeyRef<S>
+where
+    S: TorusOps,
+{
+    // GLWE, Radix
+    type Inputs = (GlweDimension, RadixCount);
+
+    fn size(t: Self::Inputs) -> usize {
+        // A scheme switch key is a collection of GLEVs encrypting the secret
+        // key polynomials multiplied by each other.
+        let number_polynomials = t.0.size.0;
+        let radix_count = t.1 .0;
+        let number_key_combinations = triangular_number_entries(number_polynomials);
+        let glwe_encryption_size = GlweCiphertextRef::<S>::size(t.0);
+
+        let glev_size = glwe_encryption_size * radix_count;
+
+        glev_size * number_key_combinations
+    }
+}
+
+impl<S> SchemeSwitchKey<S>
+where
+    S: TorusOps,
+{
+    /// Create a new zero scheme switch key.
+    pub fn new(glwe: &GlweDef, radix: &RadixDecomposition) -> Self {
+        let elems = SchemeSwitchKeyRef::<S>::size((glwe.dim, radix.count));
+
+        Self {
+            data: avec![Torus::zero(); elems],
+        }
+    }
+}
+
+impl<S> SchemeSwitchKeyRef<S>
+where
+    S: TorusOps,
+{
+    /// Returns an iterator over the components of the scheme switch key
+    /// components, which are
+    /// [`GlevCiphertext`](crate::entities::GlevCiphertext)s. Note that this
+    /// order will be the order of the secret key polynomials as if they were
+    /// laid out in an upper triangular matrix. For example, for a GLWE size of
+    /// 2, the third GLev returned will contain the message of sk_1 * sk_1
+    /// (indexed from zero) Note that this order will be the order of the secret
+    /// key polynomials as if they were laid out in an upper triangular matrix.
+    pub fn glev_ciphertexts(
+        &self,
+        params: &GlweDef,
+        radix: &RadixDecomposition,
+    ) -> GlevCiphertextIterator<S> {
+        GlevCiphertextIterator::new(
+            &self.data,
+            GlevCiphertextRef::<S>::size((params.dim, radix.count)),
+        )
+    }
+
+    /// Returns a mutable iterator over the components of the scheme switch key
+    /// components, which are
+    /// [`GlevCiphertext`](crate::entities::GlevCiphertext)s. Note that this
+    /// order will be the order of the secret key polynomials as if they were
+    /// laid out in an upper triangular matrix. For example, for a GLWE size of
+    /// 2, the third GLev returned will contain the message of sk_1 * sk_1
+    /// (indexed from zero) Note that this order will be the order of the secret
+    /// key polynomials as if they were laid out in an upper triangular matrix.
+    pub fn glev_ciphertexts_mut(
+        &mut self,
+        params: &GlweDef,
+        radix: &RadixDecomposition,
+    ) -> GlevCiphertextIteratorMut<S> {
+        GlevCiphertextIteratorMut::new(
+            &mut self.data,
+            GlevCiphertextRef::<S>::size((params.dim, radix.count)),
+        )
+    }
+
+    /// Gets the GLEV ciphertext at the given tuple index (i,j) representing the
+    /// entry for s_i * s_j
+    ///
+    /// # Arguments
+    /// * `i` - First index in the upper triangular matrix
+    /// * `j` - Second index in the upper triangular matrix
+    /// * `params` - GLWE parameters containing dimension information
+    /// * `radix` - Radix decomposition parameters
+    ///
+    /// # Panics
+    /// Panics if either index is >= the number of polynomials in the GLWE
+    /// dimension
+    pub fn get_glev_at_index(
+        &self,
+        i: usize,
+        j: usize,
+        params: &GlweDef,
+        radix: &RadixDecomposition,
+    ) -> &GlevCiphertextRef<S> {
+        let n = params.dim.size.0;
+        let linear_idx = get_linear_index(i, j, n);
+
+        self.glev_ciphertexts(params, radix)
+            .nth(linear_idx)
+            .expect("Index out of bounds")
+    }
+
+    /// Gets a mutable reference to the GLev ciphertext at the given tuple index (i,j)
+    ///
+    /// # Arguments
+    /// * `i` - First index in the upper triangular matrix
+    /// * `j` - Second index in the upper triangular matrix
+    /// * `params` - GLWE parameters containing dimension information
+    /// * `radix` - Radix decomposition parameters
+    ///
+    /// # Panics
+    /// Panics if either index is >= the number of polynomials in the GLWE
+    /// dimension
+    pub fn get_glev_at_index_mut(
+        &mut self,
+        i: usize,
+        j: usize,
+        params: &GlweDef,
+        radix: &RadixDecomposition,
+    ) -> &GlevCiphertextRef<S> {
+        let n = params.dim.size.0;
+        let linear_idx = get_linear_index(i, j, n);
+
+        self.glev_ciphertexts_mut(params, radix)
+            .nth(linear_idx)
+            .expect("Index out of bounds")
+    }
+
+    /// Compute the FFT of each of the GLev ciphertexts in the GGSW ciphertext.
+    /// The result is stored in `result`.
+    pub fn fft(
+        &self,
+        result: &mut SchemeSwitchKeyFftRef<Complex<f64>>,
+        params: &GlweDef,
+        radix: &RadixDecomposition,
+    ) {
+        self.assert_valid(params, radix);
+        result.assert_valid(params, radix);
+
+        for (s, r) in self
+            .glev_ciphertexts(params, radix)
+            .zip(result.glev_ciphertexts_mut(params, radix))
+        {
+            s.fft(r, params);
+        }
+    }
+
+    #[inline(always)]
+    /// Asserts that this entity is valid under the passed parameters.
+    pub fn assert_valid(&self, params: &GlweDef, radix: &RadixDecomposition) {
+        assert_eq!(Self::size((params.dim, radix.count)), self.data.len());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_linear_index_3x3() {
+        // Test 3x3 matrix
+        // [0,1,2]
+        // [_,3,4]
+        // [_,_,5]
+        let n = 3;
+
+        // Test upper triangle
+        assert_eq!(get_linear_index(0, 0, n), 0);
+        assert_eq!(get_linear_index(0, 1, n), 1);
+        assert_eq!(get_linear_index(0, 2, n), 2);
+        assert_eq!(get_linear_index(1, 1, n), 3);
+        assert_eq!(get_linear_index(1, 2, n), 4);
+        assert_eq!(get_linear_index(2, 2, n), 5);
+
+        // Test lower triangle (should map to upper triangle)
+        assert_eq!(get_linear_index(1, 0, n), 1);
+        assert_eq!(get_linear_index(2, 0, n), 2);
+        assert_eq!(get_linear_index(2, 1, n), 4);
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        // Test 1x1 matrix
+        assert_eq!(get_linear_index(0, 0, 1), 0);
+
+        // Test 2x2 matrix
+        let n = 2;
+        assert_eq!(get_linear_index(0, 0, n), 0);
+        assert_eq!(get_linear_index(0, 1, n), 1);
+        assert_eq!(get_linear_index(1, 1, n), 2);
+        assert_eq!(get_linear_index(1, 0, n), 1); // lower triangle
+    }
+
+    #[test]
+    fn test_matrices() {
+        for n in 1..=8 {
+            let mut index = 0;
+            // Only need to test upper triangle due to symmetry
+            for i in 0..n {
+                for j in i..n {
+                    assert_eq!(
+                        get_linear_index(i, j, n),
+                        index,
+                        "Failed at n={}, i={}, j={}",
+                        n,
+                        i,
+                        j
+                    );
+                    index += 1;
+                }
+            }
+            // Verify total number of entries
+            assert_eq!(index, triangular_number_entries(n));
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_out_of_bounds() {
+        get_linear_index(3, 2, 3); // i >= n should panic
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_out_of_bounds_2() {
+        get_linear_index(2, 3, 3); // j >= n should panic
+    }
+}

--- a/sunscreen_tfhe/src/entities/scheme_switch_key_fft.rs
+++ b/sunscreen_tfhe/src/entities/scheme_switch_key_fft.rs
@@ -1,0 +1,166 @@
+use num::{Complex, Zero};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    dst::{NoWrapper, OverlaySize},
+    entities::SchemeSwitchKeyRef,
+    GlweDef, GlweDimension, RadixCount, RadixDecomposition, TorusOps,
+};
+
+use super::{
+    get_linear_index, triangular_number_entries, GlevCiphertextFftIterator,
+    GlevCiphertextFftIteratorMut, GlevCiphertextFftRef, GlweCiphertextFftRef,
+};
+
+dst! {
+    /// The FFT variant of a scheme switch key. See
+    /// [`SchemeSwitchKey`](crate::entities::SchemeSwitchKey) for more details.
+    SchemeSwitchKeyFft,
+    SchemeSwitchKeyFftRef,
+    NoWrapper,
+    (Clone, Debug, Serialize, Deserialize),
+    ()
+}
+dst_iter! { SchemeSwitchKeyFftIterator, SchemeSwitchKeyFftIteratorMut, ParallelSchemeSwitchKeyFftIterator, ParallelSchemeSwitchKeyFftIteratorMut, NoWrapper, SchemeSwitchKeyFftRef, ()}
+
+impl OverlaySize for SchemeSwitchKeyFftRef<Complex<f64>> {
+    // GLWE, Radix
+    type Inputs = (GlweDimension, RadixCount);
+
+    fn size(t: Self::Inputs) -> usize {
+        // A scheme switch key is a collection of GLEVs encrypting the secret
+        // key polynomials multiplied by each other.
+        let number_polynomials = t.0.size.0;
+        let radix_count = t.1 .0;
+        let number_key_combinations = triangular_number_entries(number_polynomials);
+        let glwe_encryption_size = GlweCiphertextFftRef::size(t.0);
+
+        let glev_size = glwe_encryption_size * radix_count;
+
+        glev_size * number_key_combinations
+    }
+}
+
+impl SchemeSwitchKeyFft<Complex<f64>> {
+    /// Creates a new scheme switch key with FFT representation.
+    pub fn new(params: &GlweDef, radix: &RadixDecomposition) -> SchemeSwitchKeyFft<Complex<f64>> {
+        let len = SchemeSwitchKeyFftRef::size((params.dim, radix.count));
+
+        SchemeSwitchKeyFft {
+            data: avec![Complex::zero(); len],
+        }
+    }
+}
+
+impl SchemeSwitchKeyFftRef<Complex<f64>> {
+    /// Returns an iterator over the components of the scheme switch key
+    /// components, which are
+    /// [`GlevCiphertextFft`](crate::entities::GlevCiphertextFft)s. Note that
+    /// this order will be the order of the secret key polynomials as if they
+    /// were laid out in an upper triangular matrix. For example, for a GLWE
+    /// size of 2, the third GLev returned will contain the message of sk_1 *
+    /// sk_1 (indexed from zero) Note that this order will be the order of the
+    /// secret key polynomials as if they were laid out in an upper triangular
+    /// matrix.
+    pub fn glev_ciphertexts(
+        &self,
+        params: &GlweDef,
+        radix: &RadixDecomposition,
+    ) -> GlevCiphertextFftIterator<Complex<f64>> {
+        let stride = GlevCiphertextFftRef::<Complex<f64>>::size((params.dim, radix.count));
+
+        GlevCiphertextFftIterator::new(self.as_slice(), stride)
+    }
+
+    /// Returns a mutable iterator over the components of the scheme switch key
+    /// components, which are
+    /// [`GlevCiphertextFft`](crate::entities::GlevCiphertextFft)s. Note that this
+    /// order will be the order of the secret key polynomials as if they were
+    /// laid out in an upper triangular matrix. For example, for a GLWE size of
+    /// 2, the third GLev returned will contain the message of sk_1 * sk_1
+    /// (indexed from zero) Note that this order will be the order of the secret
+    /// key polynomials as if they were laid out in an upper triangular matrix.
+    pub fn glev_ciphertexts_mut(
+        &mut self,
+        params: &GlweDef,
+        radix: &RadixDecomposition,
+    ) -> GlevCiphertextFftIteratorMut<Complex<f64>> {
+        let stride = GlevCiphertextFftRef::<Complex<f64>>::size((params.dim, radix.count));
+
+        GlevCiphertextFftIteratorMut::new(self.as_mut_slice(), stride)
+    }
+
+    /// Gets the GLev ciphertext at the given tuple index (i,j) representing the
+    /// entry for s_i * s_j
+    ///
+    /// # Arguments
+    /// * `i` - First index in the upper triangular matrix
+    /// * `j` - Second index in the upper triangular matrix
+    /// * `params` - GLWE parameters containing dimension information
+    /// * `radix` - Radix decomposition parameters
+    ///
+    /// # Panics
+    /// Panics if either index is >= the number of polynomials in the GLWE dimension
+    pub fn get_glev_at_index(
+        &self,
+        i: usize,
+        j: usize,
+        params: &GlweDef,
+        radix: &RadixDecomposition,
+    ) -> &GlevCiphertextFftRef<Complex<f64>> {
+        let n = params.dim.size.0;
+        let linear_idx = get_linear_index(i, j, n);
+
+        self.glev_ciphertexts(params, radix)
+            .nth(linear_idx)
+            .expect("Index out of bounds")
+    }
+
+    /// Gets a mutable reference to the GLEV ciphertext at the given tuple index (i,j)
+    ///
+    /// # Arguments
+    /// * `i` - First index in the upper triangular matrix
+    /// * `j` - Second index in the upper triangular matrix
+    /// * `params` - GLWE parameters containing dimension information
+    /// * `radix` - Radix decomposition parameters
+    ///
+    /// # Panics
+    /// Panics if either index is >= the number of polynomials in the GLWE
+    /// dimension
+    pub fn get_glev_at_index_mut(
+        &mut self,
+        i: usize,
+        j: usize,
+        params: &GlweDef,
+        radix: &RadixDecomposition,
+    ) -> &GlevCiphertextFftRef<Complex<f64>> {
+        let n = params.dim.size.0;
+        let linear_idx = get_linear_index(i, j, n);
+
+        self.glev_ciphertexts_mut(params, radix)
+            .nth(linear_idx)
+            .expect("Index out of bounds")
+    }
+
+    /// Computes the inverse FFT of the GLev ciphertexts and stores computation
+    /// in `result`.
+    pub fn ifft<S: TorusOps>(
+        &self,
+        result: &mut SchemeSwitchKeyRef<S>,
+        params: &GlweDef,
+        radix: &RadixDecomposition,
+    ) {
+        for (s, r) in self
+            .glev_ciphertexts(params, radix)
+            .zip(result.glev_ciphertexts_mut(params, radix))
+        {
+            s.ifft(r, params);
+        }
+    }
+
+    #[inline(always)]
+    /// Asserts that this entity is valid under the passed parameters.
+    pub fn assert_valid(&self, glwe: &GlweDef, radix: &RadixDecomposition) {
+        assert_eq!(Self::size((glwe.dim, radix.count)), self.data.len());
+    }
+}

--- a/sunscreen_tfhe/src/iteration/mod.rs
+++ b/sunscreen_tfhe/src/iteration/mod.rs
@@ -1,0 +1,2 @@
+mod triangular_pairs;
+pub use triangular_pairs::*;

--- a/sunscreen_tfhe/src/iteration/triangular_pairs.rs
+++ b/sunscreen_tfhe/src/iteration/triangular_pairs.rs
@@ -1,0 +1,201 @@
+use rayon::prelude::*;
+
+/// An iterator that generates triangular pairs from a sequence.
+/// For a sequence [a, b, c], it generates pairs:
+/// [(a,a), (a,b), (a,c), (b,b), (b,c), (c,c)]
+pub struct TriangularPairs<I: Iterator> {
+    items: Vec<I::Item>,
+    outer_idx: usize, // Current outer element index
+    inner_idx: usize, // Current inner element index
+}
+
+impl<I> Iterator for TriangularPairs<I>
+where
+    I: Iterator,
+    I::Item: Clone,
+{
+    type Item = (I::Item, I::Item);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        // Check if we've exhausted all pairs
+        if self.outer_idx >= self.items.len() {
+            return None;
+        }
+
+        // Generate the current pair
+        let result = Some((
+            self.items[self.outer_idx].clone(),
+            self.items[self.inner_idx].clone(),
+        ));
+
+        // Move to next pair
+        self.inner_idx += 1;
+        if self.inner_idx >= self.items.len() {
+            self.outer_idx += 1;
+            self.inner_idx = self.outer_idx;
+        }
+
+        result
+    }
+}
+
+/// Extension trait that adds triangular pairs iteration capabilities to iterators.
+///
+/// # Examples
+///
+/// ```text
+/// use sunscreen_tfhe::iteration::triangular_pairs::TriangularPairsExt;
+///
+/// let v = vec![1, 2, 3];
+/// let pairs: Vec<_> = v.iter().triangular_pairs().collect();
+/// assert_eq!(
+///     pairs,
+///     vec![(&1, &1), (&1, &2), (&1, &3), (&2, &2), (&2, &3), (&3, &3)]
+/// );
+/// ```
+pub trait TriangularPairsExt: Iterator {
+    /// Creates an iterator that yields triangular pairs from the sequence.
+    fn triangular_pairs(self) -> TriangularPairs<Self>
+    where
+        Self: Sized,
+        Self::Item: Clone,
+    {
+        TriangularPairs {
+            items: self.collect(),
+            outer_idx: 0,
+            inner_idx: 0,
+        }
+    }
+}
+
+impl<I: Iterator> TriangularPairsExt for I {}
+
+/// A parallel iterator that generates triangular pairs from a sequence.
+/// Similar to `TriangularPairs` but processes pairs in parallel.
+pub struct ParTriangularPairs<I: ParallelIterator> {
+    items: Vec<I::Item>,
+}
+
+impl<I> ParallelIterator for ParTriangularPairs<I>
+where
+    I: ParallelIterator,
+    I::Item: Clone + Send + Sync,
+{
+    type Item = (I::Item, I::Item);
+
+    fn drive_unindexed<C>(self, consumer: C) -> C::Result
+    where
+        C: rayon::iter::plumbing::UnindexedConsumer<Self::Item>,
+    {
+        // Process pairs in parallel using nested parallel iterators
+        self.items
+            .par_iter()
+            .enumerate()
+            .flat_map(|(i, item)| {
+                // For each item, process it with itself and all subsequent items in parallel
+                self.items[i..]
+                    .par_iter()
+                    .map(move |inner_item| (item.clone(), inner_item.clone()))
+            })
+            .drive_unindexed(consumer)
+    }
+}
+
+/// Extension trait that adds parallel triangular pairs iteration capabilities to parallel iterators.
+///
+/// # Examples
+///
+/// ```text
+/// use rayon::prelude::*;
+/// use sunscreen_tfhe::iteration::triangular_pairs::ParTriangularPairsExt;
+///
+/// let v = vec![1, 2, 3];
+/// let pairs: Vec<_> = v.par_iter().par_triangular_pairs().collect();
+/// assert_eq!(
+///     pairs,
+///     vec![(&1, &1), (&1, &2), (&1, &3), (&2, &2), (&2, &3), (&3, &3)]
+/// );
+/// ```
+#[allow(unused)]
+pub trait ParTriangularPairsExt: ParallelIterator {
+    /// Creates a parallel iterator that yields triangular pairs from the sequence.
+    fn par_triangular_pairs(self) -> ParTriangularPairs<Self>
+    where
+        Self: Sized,
+        Self::Item: Clone + Send + Sync,
+    {
+        ParTriangularPairs {
+            items: self.collect(),
+        }
+    }
+}
+
+impl<I: ParallelIterator> ParTriangularPairsExt for I {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_triangular_pairs_empty() {
+        let v: Vec<i32> = vec![];
+        let pairs: Vec<_> = v.iter().triangular_pairs().collect();
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn test_triangular_pairs_single() {
+        let v = [1];
+        let pairs: Vec<_> = v.iter().triangular_pairs().collect();
+        assert_eq!(pairs, vec![(&1, &1)]);
+    }
+
+    #[test]
+    fn test_triangular_pairs_two() {
+        let v = [1, 2];
+        let pairs: Vec<_> = v.iter().triangular_pairs().collect();
+        assert_eq!(pairs, vec![(&1, &1), (&1, &2), (&2, &2)]);
+    }
+
+    #[test]
+    fn test_triangular_pairs_three() {
+        let v = [1, 2, 3];
+        let pairs: Vec<_> = v.iter().triangular_pairs().collect();
+        assert_eq!(
+            pairs,
+            vec![(&1, &1), (&1, &2), (&1, &3), (&2, &2), (&2, &3), (&3, &3),]
+        );
+    }
+
+    #[test]
+    fn test_par_triangular_pairs_empty() {
+        let v: Vec<i32> = vec![];
+        let pairs: Vec<_> = v.par_iter().par_triangular_pairs().collect();
+        assert!(pairs.is_empty());
+    }
+
+    #[test]
+    fn test_par_triangular_pairs_single() {
+        let v = vec![1];
+        let pairs: Vec<_> = v.par_iter().par_triangular_pairs().collect();
+        assert_eq!(pairs, vec![(&1, &1)]);
+    }
+
+    #[test]
+    fn test_par_triangular_pairs_two() {
+        let v = vec![1, 2];
+        let pairs: Vec<_> = v.par_iter().par_triangular_pairs().collect();
+        assert_eq!(pairs, vec![(&1, &1), (&1, &2), (&2, &2)]);
+    }
+
+    #[test]
+    fn test_par_triangular_pairs_three() {
+        let v = vec![1, 2, 3];
+        let pairs: Vec<_> = v.par_iter().par_triangular_pairs().collect();
+
+        assert_eq!(
+            pairs,
+            vec![(&1, &1), (&1, &2), (&1, &3), (&2, &2), (&2, &3), (&3, &3),]
+        );
+    }
+}

--- a/sunscreen_tfhe/src/lib.rs
+++ b/sunscreen_tfhe/src/lib.rs
@@ -6,6 +6,9 @@
 #[macro_use]
 mod dst;
 
+/// Methods for iterating over data structures.
+pub(crate) mod iteration;
+
 /// The entities module contains the main data structures used in the library.
 pub mod entities;
 

--- a/sunscreen_tfhe/src/math/polynomial.rs
+++ b/sunscreen_tfhe/src/math/polynomial.rs
@@ -123,6 +123,22 @@ pub fn polynomial_external_mad<S>(
 /// Compute `c += a * b` where `*` the multiplication of the two polynomials of
 /// degree (N - 1) modulo (X^N + 1). This is done with the naive algorithm, and
 /// hence has O(N^2) time.
+pub fn polynomial_mad_by_wrap<S>(
+    c: &mut PolynomialRef<S>,
+    a: &PolynomialRef<S>,
+    b: &PolynomialRef<S>,
+) where
+    S: TorusOps,
+    Wrapping<S>: Sub<Wrapping<S>, Output = Wrapping<S>>
+        + Add<Wrapping<S>, Output = Wrapping<S>>
+        + Mul<Wrapping<S>, Output = Wrapping<S>>,
+{
+    polynomial_mad_impl(c.as_wrapping_mut(), a.as_wrapping(), b.as_wrapping())
+}
+
+/// Compute `c += a * b` where `*` the multiplication of the two polynomials of
+/// degree (N - 1) modulo (X^N + 1). This is done with the naive algorithm, and
+/// hence has O(N^2) time.
 pub fn polynomial_mad<S>(
     c: &mut PolynomialRef<Wrapping<S>>,
     a: &PolynomialRef<Wrapping<S>>,

--- a/sunscreen_tfhe/src/ops/bootstrapping/mod.rs
+++ b/sunscreen_tfhe/src/ops/bootstrapping/mod.rs
@@ -6,3 +6,6 @@ pub use circuit_bootstrapping::*;
 
 mod programmable_bootstrapping;
 pub use programmable_bootstrapping::*;
+
+mod scheme_switch;
+pub use scheme_switch::*;

--- a/sunscreen_tfhe/src/ops/bootstrapping/scheme_switch.rs
+++ b/sunscreen_tfhe/src/ops/bootstrapping/scheme_switch.rs
@@ -1,0 +1,834 @@
+use std::{
+    num::Wrapping,
+    ops::{Add, Mul, Sub},
+};
+
+use crate::{
+    dst::FromMutSlice,
+    entities::{
+        GgswCiphertextRef, GlevCiphertextRef, GlweCiphertextRef, GlweSecretKeyRef, Polynomial,
+        PolynomialFft, PolynomialRef, SchemeSwitchKeyRef,
+    },
+    iteration::TriangularPairsExt,
+    ops::{ciphertext::decomposed_polynomial_glev_mad, encryption::encrypt_glev_ciphertext},
+    radix::PolynomialRadixIterator,
+    scratch::allocate_scratch_ref,
+    GlweDef, RadixDecomposition, Torus, TorusOps,
+};
+use num::{Complex, Zero};
+
+/// Generate a scheme switch key. This encrypts the secret key `sk` in a series
+/// of GLev encryptions under that same key.
+pub fn generate_scheme_switch_key<S>(
+    scheme_switch_key: &mut SchemeSwitchKeyRef<S>,
+    sk: &GlweSecretKeyRef<S>,
+    params: &GlweDef,
+    radix: &RadixDecomposition,
+) where
+    S: TorusOps,
+    Wrapping<S>: Sub<Wrapping<S>, Output = Wrapping<S>>
+        + Add<Wrapping<S>, Output = Wrapping<S>>
+        + Mul<Wrapping<S>, Output = Wrapping<S>>,
+{
+    params.assert_valid();
+    radix.assert_valid::<S>();
+
+    scheme_switch_key.assert_valid(params, radix);
+    sk.assert_valid(params);
+
+    let polynomial_size = params.dim.polynomial_degree.0;
+
+    let polynomial_pair_iterator = sk
+        .s(params)
+        .triangular_pairs()
+        .zip(scheme_switch_key.glev_ciphertexts_mut(params, radix));
+
+    polynomial_pair_iterator.for_each(|((s_i, s_j), glev_ciphertext)| {
+        // Using the FFT is approximately 10x faster, it takes approximately 4
+        // us to multiply two polynomials on an M2 Pro MBP of 256 dimension.
+        let mut s_i_fft = PolynomialFft::new(&vec![Complex::zero(); polynomial_size / 2]);
+        let mut s_j_fft = s_i_fft.clone();
+        let mut s_i_j_fft = s_i_fft.clone();
+
+        s_i.fft(&mut s_i_fft);
+        s_j.fft(&mut s_j_fft);
+
+        s_i_j_fft.multiply_add(&s_i_fft, &s_j_fft);
+
+        let mut s_i_j = Polynomial::<S>::zero(polynomial_size);
+        s_i_j_fft.ifft(&mut s_i_j);
+
+        // Encrypt the secret key under itself
+        encrypt_glev_ciphertext(glev_ciphertext, s_i_j.as_torus(), sk, params, radix)
+    });
+}
+
+/// Generate a GLWE encryption of (-b*s_i) by moving the body `b `into the mask `a `at
+/// a specific index location. This is the same as an encryption of the secret
+/// key times the body as the message. See the math below for more details.
+///
+/// This operation overwrites all the data in the output ciphertext, so the same
+/// output polynomial can be reused.
+///
+/// # Math derivation
+///
+/// Suppose we have $(\vec{a}, b) = \mathsf{GLWE}(m)$. Construct trivial GLWE
+/// ciphertext $t$ by placing $b$ in the $p$'th place in the basis coefficients
+/// and 0 elsewhere $t_p(b)=((0, ..., b, ... 0), 0)$. Observe what happens if we
+/// decrypt $t$ under any key $\vec{s}$:
+///
+/// $$
+/// \begin{aligned*}
+/// m = - (\sum_{i \ne p}^{[0, k)}0\cdot s_i + b \cdot s_p) - 0 \
+/// = - b \cdot s_p
+/// \end{aligned*}
+/// $$
+///
+/// Note the negation in m is due to a different convention in the decryption
+/// function for the scheme switching paper and our convention.
+///
+/// Since the error is 0 as well, we can elide the rounding step. Thus, $t$ is a
+/// $\mathsf{GLWE}$ encryption of $m \cdot s_p$ under $\vec{s}$.
+#[allow(unused)]
+fn generate_encrypted_secret_key_component<S>(
+    output: &mut GlweCiphertextRef<S>,
+    glwe_ciphertext: &GlweCiphertextRef<S>,
+    index: usize,
+    params: &GlweDef,
+) where
+    S: TorusOps,
+{
+    assert!(
+        index < params.dim.size.0,
+        "generate_encrypted_secret_key_component: index out of bounds"
+    );
+
+    let b = glwe_ciphertext.b(params);
+
+    output.zero_a_except_at_index(b, index, params);
+
+    // Set the b of the output ciphertext to zero
+    output
+        .b_mut(params)
+        .coeffs_mut()
+        .fill(Torus::from(<S as num::Zero>::zero()));
+}
+
+/// This is the same as `generate_encrypted_secret_key_component` but it assumes
+/// that all the positions where the index is not being written are already
+/// zeroed out.
+///
+/// # See Also
+///
+/// * [`generate_encrypted_secret_key_component`](generate_encrypted_secret_key_component)
+pub(crate) fn update_encrypted_secret_key_component<S>(
+    output: &mut GlweCiphertextRef<S>,
+    glwe_ciphertext: &GlweCiphertextRef<S>,
+    index: usize,
+    params: &GlweDef,
+) where
+    S: TorusOps,
+{
+    assert!(
+        index < params.dim.size.0,
+        "update_encrypted_secret_key_component: index out of bounds"
+    );
+
+    let b = glwe_ciphertext.b(params);
+
+    output.fill_a_at_index(b, index, params);
+}
+
+/// Converts a GLev ciphertext into a GGSW ciphertext using a scheme switching key.
+///
+/// # Arguments
+///
+/// * `output` - The GGSW ciphertext to store the result
+/// * `glev_ciphertext` - The input GLev ciphertext to convert, encrypted under
+///   the GGSW radix parameters
+/// * `ssk` - The scheme switching key used for conversion, encrypted under the
+///   scheme switch radix parameters
+/// * `params` - GLWE parameters defining dimensions and sizes
+/// * `radix_ggsw` - Radix decomposition parameters for GGSW operations
+/// * `radix_ss` - Radix decomposition parameters for scheme switching
+///
+/// # Example
+///
+/// ```rust
+/// use sunscreen_tfhe::{
+///     entities::{
+///         GgswCiphertext, GlevCiphertext, GlweSecretKey,
+///         Polynomial,
+///         SchemeSwitchKey,
+///     },
+///     ops::{
+///         encryption::encrypt_glev_ciphertext,
+///         bootstrapping::{generate_scheme_switch_key, scheme_switch},
+///     },
+///     GlweDef, GlweDimension, GlweSize, PolynomialDegree, rand::Stddev,
+///     RadixDecomposition, RadixCount, RadixLog,
+///     Torus,
+/// };
+///
+/// // Setup parameters. These are example values, and are not secure.
+/// let params = GlweDef {
+///     dim: GlweDimension {
+///         polynomial_degree: PolynomialDegree(256),
+///         size: GlweSize(3),
+///     },
+///     std: Stddev(1e-16),
+/// };
+/// let radix_ggsw = RadixDecomposition {
+///     count: RadixCount(6),
+///     radix_log: RadixLog(4),
+/// };
+/// let radix_ss = RadixDecomposition {
+///     count: RadixCount(8),
+///     radix_log: RadixLog(7),
+/// };
+///
+/// let polynomial_degree = params.dim.polynomial_degree.0;
+///
+/// // Create message polynomial (encrypting 1)
+/// let mut m_coeffs = vec![Torus::from(0u64); polynomial_degree];
+/// m_coeffs[0] = Torus::from(1u64);
+/// let m = Polynomial::new(&m_coeffs);
+///
+/// // Generate keys
+/// let sk = GlweSecretKey::generate_binary(&params);
+/// let mut ssk = SchemeSwitchKey::new(&params, &radix_ss);
+/// generate_scheme_switch_key(&mut ssk, &sk, &params, &radix_ss);
+///
+/// // Encrypt message as GLev
+/// let mut glev = GlevCiphertext::new(&params, &radix_ggsw);
+/// encrypt_glev_ciphertext(&mut glev, &m, &sk, &params, &radix_ggsw);
+///
+/// // Convert to GGSW
+/// let mut ggsw = GgswCiphertext::new(&params, &radix_ggsw);
+/// scheme_switch(&mut ggsw, &glev, &ssk, &params, &radix_ggsw, &radix_ss);
+/// ```
+///
+/// # See Also
+///
+/// * [`generate_scheme_switch_key`](crate::ops::bootstrapping::generate_scheme_switch_key)
+/// * [`scheme_switch_fft`](crate::ops::fft_ops::scheme_switch_fft)
+///
+/// ## Mathematical Background
+///
+/// The scheme switching process relies on a key observation about GLWE ciphertexts:
+///
+/// Given a GLWE ciphertext $(\vec{a}, b)$ encrypting message $m$, we can construct a special
+/// ciphertext $t_p(b)=((0, ..., b, ... 0), 0)$ where $b$ is placed at position $p$. When
+/// decrypted under key $\vec{s}$, this yields:
+///
+/// $$ m = - b \cdot s_p $$
+///
+/// where s_p is the p'th polynomial in the secret key.
+///
+/// For the scheme switch itself, given a GLev encryption $x=\mathsf{GLev}(m)$ with components
+/// $x_i=\mathsf{GLWE}(\frac{q}{\beta^{i+1}}m)=(\vec{a}^{(i)}, b^{(i)})$, we compute for each
+/// $i \in [0, \ell_{ggsw}), j \in [0, k)$:
+///
+/// $$ y_{i,j} = t_j(b^{(i)}) + \sum_{r=0}^{k-1} a^{(i)}_r \odot \mathsf{GLev}_{\vec{s}}(s_j \cdot s_r) $$
+///
+/// Combining all the $y_{i,j}$ GLWE encryptions over index i into a single GLev
+/// ciphertext results in a GLWE encryption of $m \cdot s_j$ under the secret
+/// key $\vec{s}$.
+///
+/// $$ z_j = \mathsf{GLev}_{\vec{s}}(m \cdot s_j) = (y_{0,j}, y_{1,j}, ..., y_{\ell_{ggsw}-1,j}) $$
+///
+/// Combining all the $z_j$ GLev encryptions into a single GGSW ciphertext
+/// results in a GGSW encryption of m.
+///
+/// $$ \mathsf{GGSW}_{\vec{s}}(m)=(z_0, z_1, ..., z_{k-1}, x) $$
+///
+/// # References
+///
+/// This specific scheme switching process is based on the following paper but
+/// modified to support GGSW ciphertexts instead of just RGSW:
+///
+/// Wang, R., Wen, Y., Li, Z., Lu, X., Wei, B., Liu, K., & Wang, K. (2024, May).
+/// Circuit bootstrapping: faster and smaller. In Annual International
+/// Conference on the Theory and Applications of Cryptographic Techniques (pp.
+/// 342-372). Cham: Springer Nature Switzerland.
+pub fn scheme_switch<S>(
+    output: &mut GgswCiphertextRef<S>,
+    glev_ciphertext: &GlevCiphertextRef<S>,
+    ssk: &SchemeSwitchKeyRef<S>,
+    params: &GlweDef,
+    radix_ggsw: &RadixDecomposition,
+    radix_ss: &RadixDecomposition,
+) where
+    S: TorusOps,
+{
+    ssk.assert_valid(params, radix_ss);
+    output.assert_valid(params, radix_ggsw);
+    glev_ciphertext.assert_valid(params, radix_ggsw);
+
+    let k = params.dim.size.0;
+
+    allocate_scratch_ref!(scratch, PolynomialRef<S>, (params.dim.polynomial_degree));
+    allocate_scratch_ref!(encoded_b_i, GlweCiphertextRef<S>, (params.dim));
+
+    // `encoded_b_i` needs to be cleared because we only update a single
+    // polynomial in the GLWE mask at a time. `scratch` does not need to be
+    // cleared because it is only used for temporary storage that is always
+    // completely overwritten.
+    encoded_b_i.clear();
+
+    for (j, output_glev) in output.rows_mut(params, radix_ggsw).enumerate() {
+        // The last element in the encryption is just the input itself.
+        if j == k {
+            output_glev.clone_from_ref(glev_ciphertext);
+            continue;
+        }
+
+        // Instead of constantly allocating new ciphertexts, we can reuse the
+        // same ciphertext and just update the components.
+        let last_index = (j as isize - 1).rem_euclid(k as isize) as usize;
+        encoded_b_i.zero_out_a_at_index(last_index, params);
+
+        for (x_i, y_i_j) in glev_ciphertext
+            .glwe_ciphertexts(params)
+            .zip(output_glev.glwe_ciphertexts_mut(params))
+        {
+            let a_i = x_i.a(params);
+
+            // An encryption of
+            // ((..., b_i, ...), 0)
+            // where the b_i is at the j-th position.
+            update_encrypted_secret_key_component(encoded_b_i, x_i, j, params);
+
+            // If we are in debug mode, we can assert that the ciphertext is
+            // correctly shaped.
+            #[cfg(debug_assertions)]
+            assert_encrypted_secret_key_component_correct_shape(
+                encoded_b_i,
+                x_i.b(params),
+                j,
+                params,
+            );
+
+            // We can clone directly into y_i_j since this will overwrite it.
+            y_i_j.clone_from_ref(encoded_b_i);
+
+            // Assert that the ciphertexts are the same length
+            assert_eq!(y_i_j.as_slice().len(), encoded_b_i.as_slice().len());
+
+            for (r, a_i_r) in a_i.enumerate() {
+                let decomp = PolynomialRadixIterator::new(a_i_r, scratch, radix_ss);
+
+                decomposed_polynomial_glev_mad(
+                    y_i_j,
+                    decomp,
+                    ssk.get_glev_at_index(j, r, params, radix_ss),
+                    params,
+                );
+            }
+        }
+    }
+}
+
+#[allow(unused)]
+pub(crate) fn assert_encrypted_secret_key_component_correct_shape<S>(
+    glwe: &GlweCiphertextRef<S>,
+    b: &PolynomialRef<Torus<S>>,
+    index: usize,
+    params: &GlweDef,
+) where
+    S: TorusOps,
+{
+    // Verify the output:
+    // 1. The mask (a) should be zero everywhere except at index
+    // 2. At index, it should contain the body of the input ciphertext
+    // 3. The body (b) should be zero
+
+    for (i, a_i) in glwe.a(params).enumerate() {
+        if i == index {
+            // At index, coefficients should match input body
+            assert_eq!(
+                a_i.coeffs(),
+                b.coeffs(),
+                "Coefficients at index {} don't match input body",
+                index
+            );
+        } else {
+            // All other positions should be zero
+            assert!(
+                a_i.coeffs()
+                    .iter()
+                    .all(|x| *x == Torus::from(<S as num::Zero>::zero())),
+                "Non-zero coefficients found at index {} (should be all zero)",
+                i
+            );
+        }
+    }
+
+    // Verify body is zero
+    assert!(
+        glwe.b(params)
+            .coeffs()
+            .iter()
+            .all(|x| *x == Torus::from(<S as num::Zero>::zero())),
+        "Output body contains non-zero values"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+
+    use rand::{thread_rng, RngCore};
+
+    use crate::{
+        entities::{
+            GgswCiphertext, GlevCiphertext, GlweCiphertext, GlweSecretKey, SchemeSwitchKey,
+        },
+        high_level::{
+            self,
+            encryption::{decrypt_glwe, encrypt_glwe},
+            TEST_GLWE_DEF_2, TEST_RADIX,
+        },
+        ops::{
+            encryption::{
+                decrypt_ggsw_ciphertext, decrypt_glev_ciphertext, decrypt_glwe_ciphertext,
+            },
+            fft_ops::cmux,
+        },
+        polynomial::{polynomial_external_mad, polynomial_mad_by_wrap},
+        PlaintextBits, RadixCount, RadixLog, Torus,
+    };
+
+    use super::*;
+
+    const RADIX_SS: RadixDecomposition = RadixDecomposition {
+        count: RadixCount(8),
+        radix_log: RadixLog(7),
+    };
+
+    const RADIX_GGSW: RadixDecomposition = RadixDecomposition {
+        count: RadixCount(6),
+        radix_log: RadixLog(4),
+    };
+
+    #[test]
+    fn basic_scheme_switch_key_generation() {
+        // Setup basic parameters
+        let params = TEST_GLWE_DEF_2;
+        let radix = TEST_RADIX;
+
+        let glwe_size = params.dim.size.0;
+
+        // Generate a secret key
+        let sk = GlweSecretKey::<u64>::generate_binary(&params);
+
+        // Create scheme switch key
+        let mut ssk = SchemeSwitchKey::<u64>::new(&params, &radix);
+
+        // Generate the scheme switch key
+        generate_scheme_switch_key(&mut ssk, &sk, &params, &radix);
+
+        // Basic validity checks
+        ssk.assert_valid(&params, &radix);
+
+        // Check dimensions
+        let expected_glev_count = (glwe_size * (glwe_size + 1)) / 2;
+        assert_eq!(
+            ssk.glev_ciphertexts(&params, &radix).count(),
+            expected_glev_count
+        );
+
+        // Check that the size of the glevs matches the size of the scheme switch key
+        let ssk_len = ssk.as_slice().len();
+        let mut glev_length = 0;
+
+        for glev in ssk.glev_ciphertexts(&params, &radix) {
+            glev_length += glev.as_slice().len();
+        }
+
+        assert_eq!(ssk_len, glev_length);
+
+        // Check that the glevs are in the order we expect
+        let indices = (0..glwe_size).collect::<Vec<_>>();
+        let triangular_points = indices.iter().triangular_pairs().collect::<Vec<_>>();
+
+        for ((i, j), glev) in triangular_points
+            .into_iter()
+            .zip(ssk.glev_ciphertexts(&params, &radix))
+        {
+            let glev_from_index = ssk.get_glev_at_index(*i, *j, &params, &radix);
+
+            assert_eq!(glev.as_slice(), glev_from_index.as_slice());
+        }
+    }
+
+    #[test]
+    fn scheme_switch_key_glev_ciphertext_content() {
+        let params = TEST_GLWE_DEF_2;
+        let radix = TEST_RADIX;
+
+        let sk = GlweSecretKey::<u64>::generate_binary(&params);
+
+        let mut ssk = SchemeSwitchKey::<u64>::new(&params, &radix);
+
+        generate_scheme_switch_key(&mut ssk, &sk, &params, &radix);
+
+        let sk_componets = sk.s(&params).collect::<Vec<_>>();
+
+        for (i, s_i) in sk_componets.iter().enumerate() {
+            for (j, s_j) in sk_componets.iter().enumerate().skip(i) {
+                let glev_ciphertext = ssk.get_glev_at_index(i, j, &params, &radix);
+                let mut s_i_j = Polynomial::<u64>::zero(params.dim.polynomial_degree.0);
+                polynomial_mad_by_wrap(&mut s_i_j, s_i, s_j);
+
+                // Note the modulus here to ensure that the polynomial is within
+                // the correct range
+                let s_i_j = s_i_j.map(|x| x % (1 << (radix.radix_log.0)));
+
+                let mut pt = Polynomial::<Torus<u64>>::zero(params.dim.polynomial_degree.0);
+
+                decrypt_glev_ciphertext(&mut pt, glev_ciphertext, &sk, &params, &radix);
+
+                assert_eq!(s_i_j.as_torus(), pt.as_ref());
+            }
+        }
+    }
+
+    #[test]
+    fn scheme_switch_key_symmetric() {
+        let params = TEST_GLWE_DEF_2;
+        let radix = TEST_RADIX;
+
+        let number_polynomials = params.dim.size.0;
+
+        let sk = GlweSecretKey::<u64>::generate_binary(&params);
+
+        let mut ssk = SchemeSwitchKey::<u64>::new(&params, &radix);
+
+        generate_scheme_switch_key(&mut ssk, &sk, &params, &radix);
+
+        let coordinates = (0..number_polynomials).collect::<Vec<_>>();
+
+        for (i, j) in coordinates.iter().triangular_pairs() {
+            assert_eq!(
+                ssk.get_glev_at_index(*i, *j, &params, &radix).as_slice(),
+                ssk.get_glev_at_index(*j, *i, &params, &radix).as_slice()
+            );
+        }
+    }
+
+    #[test]
+    fn update_encrypted_secret_key_component_correct_shape() {
+        let params = TEST_GLWE_DEF_2;
+
+        // Create a test GLWE ciphertext with known values
+        let mut input_glwe = GlweCiphertext::<u64>::new(&params);
+
+        // Fill the body (b) with some test values
+        for (i, coeff) in input_glwe
+            .b_mut(&params)
+            .coeffs_mut()
+            .iter_mut()
+            .enumerate()
+        {
+            *coeff = Torus::from((i as u64) % 2);
+        }
+
+        // Test generating encrypted secret key component at different indices
+        for test_index in 0..params.dim.size.0 {
+            // Create output ciphertext. We cannot write over it when using the
+            // update function.
+            let mut output_glwe = GlweCiphertext::<u64>::new(&params);
+
+            // Generate the encrypted secret key component
+            update_encrypted_secret_key_component(
+                &mut output_glwe,
+                &input_glwe,
+                test_index,
+                &params,
+            );
+
+            assert_encrypted_secret_key_component_correct_shape(
+                &output_glwe,
+                input_glwe.b(&params),
+                test_index,
+                &params,
+            );
+        }
+    }
+
+    #[test]
+    fn equivalent_update_and_generate_encrypted_secret_key_component() {
+        let params = TEST_GLWE_DEF_2;
+
+        // Create a test GLWE ciphertext with known values
+        let mut input_glwe = GlweCiphertext::<u64>::new(&params);
+
+        // Fill the body (b) with some test values
+        for (i, coeff) in input_glwe
+            .b_mut(&params)
+            .coeffs_mut()
+            .iter_mut()
+            .enumerate()
+        {
+            *coeff = Torus::from((i as u64) % 2);
+        }
+
+        let mut output_glwe = GlweCiphertext::<u64>::new(&params);
+        let mut reused_glwe = GlweCiphertext::<u64>::new(&params);
+
+        // Test generating encrypted secret key component at different indices
+        for test_index in 0..params.dim.size.0 {
+            // Create output ciphertext. We need to zero out the previous mask
+            // while using the update function since it only edits the specific
+            // mask element.
+            if test_index > 0 {
+                output_glwe.zero_out_a_at_index(test_index - 1, &params);
+            }
+
+            // Generate the encrypted secret key component
+            update_encrypted_secret_key_component(
+                &mut output_glwe,
+                &input_glwe,
+                test_index,
+                &params,
+            );
+
+            generate_encrypted_secret_key_component(
+                &mut reused_glwe,
+                &input_glwe,
+                test_index,
+                &params,
+            );
+
+            for (output_a, reused_a) in output_glwe.a(&params).zip(reused_glwe.a(&params)) {
+                assert_eq!(output_a.coeffs(), reused_a.coeffs());
+            }
+
+            assert_eq!(
+                output_glwe.b(&params).coeffs(),
+                reused_glwe.b(&params).coeffs()
+            );
+        }
+    }
+
+    #[test]
+    fn generate_encrypted_secret_key_component_secret_key_m_is_correct() {
+        // Setup basic parameters
+        let params = TEST_GLWE_DEF_2;
+        let polynomial_degree = params.dim.polynomial_degree.0;
+        let number_polynomials = params.dim.size.0;
+        let plaintext_bits = PlaintextBits(1);
+        let modulus = 1 << plaintext_bits.0;
+
+        // Shouldn't matter what this is since we are testing the relation that
+        // the `generate_encrypted_secret_key_component` should result in a
+        // message of m = b_i * s_i.
+        let m_coeffs = (0..polynomial_degree)
+            .map(|_| 1 % modulus)
+            .collect::<Vec<_>>();
+        let m = Polynomial::new(&m_coeffs);
+
+        let sk = GlweSecretKey::<u64>::generate_binary(&params);
+
+        let glwe_ciphertext = encrypt_glwe(&m, &sk, &params, plaintext_bits);
+
+        let b = glwe_ciphertext.b(&params);
+        let b_u64 = Polynomial::new(&b.coeffs().iter().map(|x| x.inner()).collect::<Vec<_>>());
+
+        for index in 0..number_polynomials {
+            let mut b_encoded_in_glwe = GlweCiphertext::new(&params);
+            update_encrypted_secret_key_component(
+                &mut b_encoded_in_glwe,
+                &glwe_ciphertext,
+                index,
+                &params,
+            );
+
+            assert_encrypted_secret_key_component_correct_shape(
+                &b_encoded_in_glwe,
+                b,
+                index,
+                &params,
+            );
+
+            let mut m_from_b_encoded = Polynomial::zero(b.len());
+
+            decrypt_glwe_ciphertext(&mut m_from_b_encoded, &b_encoded_in_glwe, &sk, &params);
+
+            let m_from_b_encoded = m_from_b_encoded.map(|x| x.inner());
+
+            let mut expected_m_from_b_encoded = Polynomial::<Torus<u64>>::zero(polynomial_degree);
+
+            let sk_component = sk.s(&params).collect::<Vec<_>>()[index];
+            polynomial_external_mad(
+                &mut expected_m_from_b_encoded,
+                b_u64.as_torus(),
+                sk_component,
+            );
+
+            // Note that we need to negate the result from what we see in the paper,
+            // as the paper uses a different convention for the body than our
+            // implementation.
+            let expected_m_from_b_encoded = expected_m_from_b_encoded.map(|x| (x.wrapping_neg()));
+
+            assert_eq!(
+                expected_m_from_b_encoded,
+                m_from_b_encoded,
+                "The decrypted secret key component did not match the expected result. The expected result is -b * s_i where b is the body of the original ciphertext and s_i is the secret key component."
+            );
+        }
+    }
+
+    fn _scheme_switch_correct_message(message: u64) {
+        let params = TEST_GLWE_DEF_2;
+        let polynomial_degree = params.dim.polynomial_degree.0;
+
+        // Create the messsage polynomial
+        let mut m_coeffs = (0..polynomial_degree)
+            .map(|_| Torus::from(0u64))
+            .collect::<Vec<_>>();
+        m_coeffs[0] = Torus::from(message);
+        let m = Polynomial::new(&m_coeffs);
+
+        // Generate the keys
+        let sk = GlweSecretKey::<u64>::generate_binary(&params);
+
+        let mut ssk = SchemeSwitchKey::<u64>::new(&params, &RADIX_SS);
+        generate_scheme_switch_key(&mut ssk, &sk, &params, &RADIX_SS);
+
+        // Encrypt the message
+        let mut glev_ciphertext = GlevCiphertext::new(&params, &RADIX_GGSW);
+        encrypt_glev_ciphertext(&mut glev_ciphertext, &m, &sk, &params, &RADIX_GGSW);
+
+        // Perform the scheme switch
+        let mut ggsw_ciphertext = GgswCiphertext::new(&params, &RADIX_GGSW);
+        scheme_switch(
+            &mut ggsw_ciphertext,
+            &glev_ciphertext,
+            &ssk,
+            &params,
+            &RADIX_GGSW,
+            &RADIX_SS,
+        );
+
+        let mut decrypted_ggsw = Polynomial::zero(polynomial_degree);
+        decrypt_ggsw_ciphertext(
+            &mut decrypted_ggsw,
+            &ggsw_ciphertext,
+            &sk,
+            &params,
+            &RADIX_GGSW,
+        );
+
+        // We got back the same encrypted message. However, this only shows that
+        // the last GLev is implemented properly, so now we additional tests to
+        // check the rest.
+        assert_eq!(
+            m_coeffs,
+            decrypted_ggsw.coeffs(),
+            "The decrypted message did not match the expected message."
+        );
+
+        // Check that all the GLev ciphertexts are correct
+        for (i, (glev_component, sk_component)) in ggsw_ciphertext
+            .rows(&params, &RADIX_GGSW)
+            .zip(sk.s(&params))
+            .enumerate()
+        {
+            let mut decrypted_glev_component = Polynomial::zero(polynomial_degree);
+            decrypt_glev_ciphertext(
+                &mut decrypted_glev_component,
+                glev_component,
+                &sk,
+                &params,
+                &RADIX_GGSW,
+            );
+
+            let mut expected = Polynomial::zero(polynomial_degree);
+
+            // Need to negate here because we are using the opposite convention
+            // for the encryption equation where b is negative.
+            let neg_sk = sk_component.map(|x| x.wrapping_neg());
+            polynomial_external_mad(&mut expected, &m, &neg_sk);
+
+            let expected = expected.map(|x| Torus::from(x.inner() % (1 << RADIX_GGSW.radix_log.0)));
+
+            assert_eq!(
+                expected, decrypted_glev_component,
+                "{} glev decryption failed",
+                i
+            );
+        }
+    }
+
+    #[test]
+    fn scheme_switch_correct_message() {
+        for _ in 0..10 {
+            let message = thread_rng().next_u64() % 2;
+            _scheme_switch_correct_message(message);
+        }
+    }
+
+    fn _can_cmux_after_scheme_switch(message: u64) {
+        let params = TEST_GLWE_DEF_2;
+        let polynomial_degree = params.dim.polynomial_degree.0;
+        let plaintext_bits = PlaintextBits(1);
+
+        // Create the messsage polynomial
+        let mut m_coeffs = (0..polynomial_degree)
+            .map(|_| Torus::from(0u64))
+            .collect::<Vec<_>>();
+        m_coeffs[0] = Torus::from(message);
+        let m = Polynomial::new(&m_coeffs);
+
+        // Generate the keys
+        let sk = GlweSecretKey::<u64>::generate_binary(&params);
+
+        let mut ssk = SchemeSwitchKey::<u64>::new(&params, &RADIX_SS);
+        generate_scheme_switch_key(&mut ssk, &sk, &params, &RADIX_SS);
+
+        // Encrypt the message
+        let mut glev_ciphertext = GlevCiphertext::new(&params, &RADIX_GGSW);
+        encrypt_glev_ciphertext(&mut glev_ciphertext, &m, &sk, &params, &RADIX_GGSW);
+
+        // Perform the scheme switch
+        let mut ggsw_ciphertext = GgswCiphertext::new(&params, &RADIX_GGSW);
+        scheme_switch(
+            &mut ggsw_ciphertext,
+            &glev_ciphertext,
+            &ssk,
+            &params,
+            &RADIX_GGSW,
+            &RADIX_SS,
+        );
+
+        // Generate the GLWE encryptions of 0 and 1
+        let zero = Polynomial::zero(polynomial_degree);
+        let mut one = Polynomial::zero(polynomial_degree);
+        one.coeffs_mut()[0] = 1;
+
+        let glwe_zero = encrypt_glwe(&zero, &sk, &params, plaintext_bits);
+        let glwe_one = encrypt_glwe(&one, &sk, &params, plaintext_bits);
+
+        // Convert the ggsw ciphertext to the fft domain
+        let b_fft = &high_level::fft::fft_ggsw(&ggsw_ciphertext, &params, &RADIX_GGSW);
+
+        // Perform the cmux operation
+        let mut c = GlweCiphertext::new(&params);
+        cmux(&mut c, &glwe_zero, &glwe_one, b_fft, &params, &RADIX_GGSW);
+
+        // Decrypt the result
+        let c_decrypted = decrypt_glwe(&c, &sk, &params, plaintext_bits);
+
+        let expected = if message == 0 { zero } else { one };
+        assert_eq!(expected, c_decrypted);
+    }
+
+    #[test]
+    fn can_cmux_after_scheme_switch() {
+        for _ in 0..10 {
+            let message = thread_rng().next_u64() % 2;
+            _can_cmux_after_scheme_switch(message);
+        }
+    }
+}

--- a/sunscreen_tfhe/src/ops/ciphertext/glev_ciphertext_ops.rs
+++ b/sunscreen_tfhe/src/ops/ciphertext/glev_ciphertext_ops.rs
@@ -14,6 +14,7 @@ use super::{glwe_polynomial_mad, glwe_scalar_mad};
 ///
 /// # Remarks
 /// This functions takes a PolynomialRadixIterator to perform the decomposition.
+/// This function is also known as the gadget product.
 pub fn decomposed_polynomial_glev_mad<S>(
     c: &mut GlweCiphertextRef<S>,
     mut a: PolynomialRadixIterator<S>,

--- a/sunscreen_tfhe/src/ops/encryption/glwe_encryption.rs
+++ b/sunscreen_tfhe/src/ops/encryption/glwe_encryption.rs
@@ -47,6 +47,11 @@ pub fn encrypt_glwe_ciphertext_secret_generic<S>(
     // b = A * S + m
     polynomial_add_assign(b, msg);
 
+    // Do not add e if the standard deviation is zero
+    if params.std.0 == 0.0 {
+        return;
+    }
+
     let e = Polynomial::new(
         &(0..msg.len())
             .map(|_| normal_torus::<S>(params.std))


### PR DESCRIPTION
Implements scheme switching, which allows GLevs to be converted to GGSW

# Background
Let $\mathcal{R}=\mathbb{Z_q}[X]/(X^N+1)$ for power of two $N$.

Recall that $\mathsf{GLEV}_{\vec{s}}(m)=[ \mathsf{GLWE}(\frac{q}{\beta^1}m), \mathsf{GLWE}(\frac{q}{\beta^2}m), ..., \mathsf{GLWE}(\frac{q}{\beta^\ell}m) ]$ where $\beta$ and $\ell$ are scheme parameters that define a radix decomposition.

Furthermore, recall the gadget product $\odot$ between $a \in \mathcal{R}$ and $\mathsf{GLEV}(m)$:

$$
a \odot \mathsf{GLEV}(m):=\sum_{i=0}^{\ell-1}\mathsf{Decomp}_{i, \beta}(a)\times\mathsf{GLWE}(\frac{q}{\beta^{i+1}}m)
$$
$$
\approx\mathsf{GLWE}(am)
$$

# Scheme switching
## Keygen
Given a GLWE scheme with poly degree $N$ and GLWE size $k$ and secret key $\vec{s}$, define a scheme switching key as follows:

* Let $\mathbf{sk} = \vec{s} \otimes \vec{s}$
* Compute scheme switching key $\mathbf{s_{ss}}$ where $\mathbf{s_{ss}}^{i,j}=\mathsf{GLEV_{\vec{s}}}(\mathbf{sk}_{i,j})$ for $i, j\in [0, k)$.
* Observe that since $\mathbf{sk_{i,j}}=\mathbf{sk_{j, i}}$, we can reduce our keysize by roughly half. Simply encrypt only the lower half of the matrix and mirror requests in the upper half. E.g. when an algorithm requests $i=2, j=3$, return the encryption for $i=3, j=2$

## Algorithm
### First, an observation
Suppose we have $(\vec{a}, b) = \mathsf{GLWE}(m)$. Construct trivial GLWE ciphertext $t$ by placing $b$ in the $p$'th place in the basis coefficients and 0 elsewhere $t_p(b)=((0, ..., b, ... 0), 0)$. Observe what happens if we decrypt $t$ under any key $\vec{s}$:

$$
m = -(\sum_{i \ne p}^{[0, k)}0\cdot s_i + b \cdot s_p) - 0
$$

$$
= -b \cdot s_p
$$

Since the error is 0 as well, we can elide the rounding step. Thus, $t$ is a $\mathsf{GLWE}$ encryption of $m \cdot s_p$ under $\vec{s}$.

This result is from the convention that the encryption equation is $b = a \cdot s + m + e$, which is what we use in our TFHE variant. The "Circuit Bootstrapping: Faster and Smaller" paper uses the convention $b = -a \cdot s + m + e$; either is valid as long as the definition is consistent. The next section assumes the all positive convention we use.

### Our regularly scheduled program
Given $x=\mathsf{GLEV}(m)$, we have $x_i=\mathsf{GLWE}(\frac{q}{\beta^{i+1}}m)=(\vec{a}^{(i)}, b^{(i)}), i\in[0,\ell_{ggsw})$.

For each $i \in [0, \ell_{ggsw}), j \in [0, k)$ compute using $\mathsf{s_{ss}}^{j,r}$ where $r \in [0, k)$

$$
y_{i, j}=t_j(b^{(i)}) + \sum_{r=0}^{k-1} a^{(i)}_r \odot \mathsf{GLEV}_{\vec{s}}(s_j \cdot s_r)=\mathsf{GLWE}_{\vec{s}}(\sum_{r=0}^{k-1}a^{(i)}_r \cdot s_r \cdot s_j - b^{(i)}\cdot s_j)
$$
$$
=\mathsf{GLWE}_{\vec{s}}((\sum_{r=0}^{k-1}a^{(i)}_r \cdot s_m - b^{(i)})\cdot s_j)
$$
$$
=\mathsf{GLWE}_{\vec{s}}(-\frac{q}{\beta^{i+1}}\cdot m \cdot s_j + e_i \cdot s_j)
$$

Note the $e_i$ term is small if $s_j$ is small (i.e. binary), and thus we are left with encryptions of $-s_j \cdot m$

Further note, the radix decomposition in the above $\odot$ is $\beta_{ss}, \ell_{ss}$, which may be distinct from $(\beta_{ggsw}, \ell_{ggsw})$

Let $z_j=\mathsf{GLEV}_{\vec{s}}(m \cdot s_j)=(y_{0,j}, y_{1,j}, ..., y_{\ell_{ggsw}-1, j})$

Output $\mathsf{GGSW}_{\vec{s}}(m)=(z_0, z_1, ..., z_{k-1}, x)$

# References

- Wang, R., Wen, Y., Li, Z., Lu, X., Wei, B., Liu, K., & Wang, K. (2024, May). Circuit bootstrapping: faster and smaller. In Annual International Conference on the Theory and Applications of Cryptographic Techniques (pp. 342-372). Cham: Springer Nature Switzerland. [Circuit Bootstrapping Faster and Smaller.pdf](https://github.com/user-attachments/files/17986823/Circuit.Bootstrapping.Faster.and.Smaller.pdf)

- De Micheli, G., Kim, D., Micciancio, D., Suhl, A.: Faster amortized FHEW bootstrapping using ring automorphisms. Cryptology ePrint Archive (2023) [Faster Amortized FHEW Bootstrapping Using Ring Automorphisms.pdf](https://github.com/user-attachments/files/17986824/Faster.Amortized.FHEW.Bootstrapping.Using.Ring.Automorphisms.pdf)
