### PR TITLE
Remove docs publishing github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,16 +35,3 @@ jobs:
     - name: Build docs
       run: ../mdBook/target/release/mdbook build
       working-directory: ./sunscreen_docs
-    - name: Write to S3
-      run: aws s3 cp book s3://sunscreen-docs --recursive
-      working-directory: ./sunscreen_docs
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: us-west-2
-    - name: Invalidate Cloudfront
-      run: aws cloudfront create-invalidation --distribution-id E250PLIECML3N3 --paths "/*"
-      env:
-        AWS_ACCESS_KEY_ID: ${{ secrets.DOCS_ACCESS_KEY_ID }}
-        AWS_SECRET_ACCESS_KEY: ${{ secrets.DOCS_SECRET_ACCESS_KEY }}
-        AWS_DEFAULT_REGION: us-west-2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,28 +77,6 @@ jobs:
       run: ../mdBook/target/release/mdbook test -L dependency=../target/mdbook/deps --extern sunscreen=../target/mdbook/libsunscreen.rlib --extern bincode=../target/mdbook/libbincode.rlib
       working-directory: ./sunscreen_docs
 
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v3
-      with:
-        submodules: 'recursive'
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cargo/bin/
-          ~/.cargo/registry/index/
-          ~/.cargo/registry/cache/
-          ~/.cargo/git/db/
-          target/
-        key: ${{ runner.os }}-cargo-clippy-${{ hashFiles('Cargo.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-cargo-clippy-
-          ${{ runner.os }}-cargo-
-    # Check the submitted change passes the clippy linter
-    - name: Cargo clippy
-      run: cargo clippy --release --all-targets -- --deny warnings
-
   api_docs:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
As it says on the tin. The docs at docs.sunscreen.tech are being replaced by the new compiler docs.